### PR TITLE
Fix bug when res.req has query param

### DIFF
--- a/lib/resValidator.js
+++ b/lib/resValidator.js
@@ -18,6 +18,7 @@ const util = require('util');
 const fs = require('fs-extra');
 const yaml = require('js-yaml');
 const path = require('path');
+const url = require('url');
 const OpenAPISchemaValidator = require('openapi-schema-validator').default;
 const OpenAPIResponseValidator = require('openapi-response-validator').default;
 
@@ -38,7 +39,7 @@ module.exports = function(pathToOpenApiSpec) {
       this.assert(
         !validationError,
         `expected res to satisfy API spec:\n${util.inspect(validationError)}`,
-        `expected res not to satisfy API spec for '${expectedResStatus}' response defined for endpoint '${res.req.method} ${res.req.path}' in OpenAPI spec\nres: ${responseSummary}`,
+        `expected res not to satisfy API spec for '${expectedResStatus}' response defined for endpoint '${res.req.method} ${getPath(res.req)}' in OpenAPI spec\nres: ${responseSummary}`,
       );
     });
   };
@@ -69,7 +70,8 @@ function parseOpenApiFile(filePath) {
 }
 
 function checkApiSpecDefinesExpectedResponse(res, expectedResStatus, openApiSpec) {
-  const path = res.req.path;
+  const path = getPath(res.req);
+
   const routeObj = openApiSpec.paths[path];
   if (!routeObj) {
     throw new Error(`No '${path}' route defined in OpenAPI spec`);
@@ -101,6 +103,12 @@ function validateResAgainstApiSpec(res, expectedResStatus, openApiSpec) {
 }
 
 function extractExpectedResponsesFromApiSpec(res, openApiSpec) {
-  const { path, method } = res.req;
+  const { req } = res;
+  const path = getPath(req);
+  const { method } = req;
   return openApiSpec.paths[path][method.toLowerCase()].responses;
+}
+
+function getPath(req) {
+  return url.parse(req.path).pathname;
 }

--- a/lib/resValidator.js
+++ b/lib/resValidator.js
@@ -39,7 +39,7 @@ module.exports = function(pathToOpenApiSpec) {
       this.assert(
         !validationError,
         `expected res to satisfy API spec:\n${util.inspect(validationError)}`,
-        `expected res not to satisfy API spec for '${expectedResStatus}' response defined for endpoint '${res.req.method} ${getPath(res.req)}' in OpenAPI spec\nres: ${responseSummary}`,
+        `expected res not to satisfy API spec for '${expectedResStatus}' response defined for endpoint '${res.req.method} ${getPathName(res.req)}' in OpenAPI spec\nres: ${responseSummary}`,
       );
     });
   };
@@ -70,7 +70,7 @@ function parseOpenApiFile(filePath) {
 }
 
 function checkApiSpecDefinesExpectedResponse(res, expectedResStatus, openApiSpec) {
-  const path = getPath(res.req);
+  const path = getPathName(res.req);
 
   const routeObj = openApiSpec.paths[path];
   if (!routeObj) {
@@ -104,11 +104,11 @@ function validateResAgainstApiSpec(res, expectedResStatus, openApiSpec) {
 
 function extractExpectedResponsesFromApiSpec(res, openApiSpec) {
   const { req } = res;
-  const path = getPath(req);
+  const path = getPathName(req);
   const { method } = req;
   return openApiSpec.paths[path][method.toLowerCase()].responses;
 }
 
-function getPath(req) {
+function getPathName(req) {
   return url.parse(req.path).pathname;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-openapi-response-validator",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Simple Chai support for asserting that HTTP responses satisfy an OpenAPI spec",
   "main": "index.js",
   "scripts": {

--- a/test/exampleOpenApiFiles/valid/openapi3.yml
+++ b/test/exampleOpenApiFiles/valid/openapi3.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
-  title: Example API
-  description: Example OpenApi 3 spec
+  title: Example OpenApi 3 spec
+  description: Has a path with various responses to use in testing
   version: 0.1.0
 paths:
   /test:

--- a/test/unit/assertions/satisfyApiSpec.test.js
+++ b/test/unit/assertions/satisfyApiSpec.test.js
@@ -38,50 +38,73 @@ for (const spec of openApiSpecs) {
   describe(`expect(res).to.satisfyApiSpec (using an OpenAPI ${openApiVersion} spec)`, function () {
     describe('when \'res\' matches a response defined in the API spec', function () {
       describe('\'res\' satisfies the spec', function () {
-        describe('spec expects res.body to be a string', function () {
-          const res = {
-            status: 200,
-            req: {
-              method: 'GET',
-              path: '/test',
-            },
-            body: 'valid body (string)',
-          };
+        describe('spec expects res.body to', function () {
+          describe('be a string', function () {
+            const res = {
+              status: 200,
+              req: {
+                method: 'GET',
+                path: '/test',
+              },
+              body: 'valid body (string)',
+            };
 
-          it('passes', function () {
-            expect(res).to.satisfyApiSpec;
+            it('passes', function () {
+              expect(res).to.satisfyApiSpec;
+            });
+
+            it('fails when using .not', function () {
+              const assertion = () => expect(res).to.not.satisfyApiSpec;
+              expect(assertion).to.throw('expected res not to satisfy API spec for \'200\' response defined for endpoint \'GET /test\' in OpenAPI spec');
+            });
           });
 
-          it('fails when using .not', function () {
-            const assertion = () => expect(res).to.not.satisfyApiSpec;
-            expect(assertion).to.throw('expected res not to satisfy API spec for \'200\' response defined for endpoint \'GET /test\' in OpenAPI spec');
+          describe('match a (string) schema', function () {
+            const res = {
+              status: 201,
+              req: {
+                method: 'GET',
+                path: '/test',
+              },
+              body: 'valid body (string)',
+            };
+
+            it('passes', function () {
+              expect(res).to.satisfyApiSpec;
+            });
+
+            it('fails when using .not', function () {
+              const assertion = () => expect(res).to.not.satisfyApiSpec;
+              expect(assertion).to.throw('expected res not to satisfy API spec for \'201\' response defined for endpoint \'GET /test\' in OpenAPI spec');
+            });
+          });
+
+          describe('be empty', function () {
+            const res = {
+              status: 204,
+              req: {
+                method: 'GET',
+                path: '/test',
+              },
+            };
+
+            it('passes', function () {
+              expect(res).to.satisfyApiSpec;
+            });
+
+            it('fails when using .not', function () {
+              const assertion = () => expect(res).to.not.satisfyApiSpec;
+              expect(assertion).to.throw('expected res not to satisfy API spec for \'204\' response defined for endpoint \'GET /test\' in OpenAPI spec');
+            });
           });
         });
-        describe('spec expects res.body to match a (string) schema', function () {
-          const res = {
-            status: 201,
-            req: {
-              method: 'GET',
-              path: '/test',
-            },
-            body: 'valid body (string)',
-          };
 
-          it('passes', function () {
-            expect(res).to.satisfyApiSpec;
-          });
-
-          it('fails when using .not', function () {
-            const assertion = () => expect(res).to.not.satisfyApiSpec;
-            expect(assertion).to.throw('expected res not to satisfy API spec for \'201\' response defined for endpoint \'GET /test\' in OpenAPI spec');
-          });
-        });
-        describe('spec expects res.body to be empty', function () {
+        describe('res.req.path has a query parameter', function () {
           const res = {
             status: 204,
             req: {
               method: 'GET',
-              path: '/test',
+              path: '/test?exampleQueryParam=foo',
             },
           };
 
@@ -95,6 +118,7 @@ for (const spec of openApiSpecs) {
           });
         });
       });
+
       describe('\'res\' does NOT satisfy the spec', function () {
         describe('spec expects a different res.status', function () {
           const res = {


### PR DESCRIPTION
Previously, if the user's OpenAPI doc defined a `/test` path, and their server responded with a `res.req.path` of `'/test?exampleQueryParam=foo'`, we would not recognise that the two pathnames were the same.

This PR fixes that and adds a test case proving it.

(Aside from that, much of the diff is just indentation)