### PR TITLE
Add support for multiple servers defined in the OpenAPI spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Chai OpenAPI Response Validator
 
+[![downloads](https://img.shields.io/npm/dm/chai-openapi-response-validator)](https://www.npmjs.com/package/chai-openapi-response-validator)
+[![npm](https://img.shields.io/npm/v/chai-openapi-response-validator.svg)](https://www.npmjs.com/package/chai-openapi-response-validator)
 [![Build Status](https://travis-ci.com/RuntimeTools/chai-openapi-response-validator.svg?branch=master)](https://travis-ci.com/RuntimeTools/chai-openapi-response-validator)
+![dependencies](https://img.shields.io/david/RuntimeTools/chai-openapi-response-validator)
 
 Simple Chai support for asserting that HTTP responses satisfy an OpenAPI spec.
 

--- a/lib/resValidator.js
+++ b/lib/resValidator.js
@@ -73,7 +73,6 @@ function parseOpenApiFile(filePath) {
 
 function findResExpectedByApiSpec(res, openApiSpec) {
   const openApiPath = getOAPath(res.req, openApiSpec);
-
   const pathObj = openApiSpec.paths[openApiPath];
   if (!pathObj) {
     throw new Error(`No '${openApiPath}' path defined in OpenAPI spec`);
@@ -111,7 +110,7 @@ function validateResAgainstApiSpec(res, expectedResponse, openApiSpec) {
 
 
 function getOAPath(req, openApiSpec) {
-  let pathname = url.parse(req.path).pathname; // excludes the query (because: path = pathname + query)
+  const pathname = url.parse(req.path).pathname; // excludes the query (because: path = pathname + query)
 
   const serverUrl = getServerUrlUsed(pathname, openApiSpec.servers);
 
@@ -119,17 +118,16 @@ function getOAPath(req, openApiSpec) {
   if (openApiSpec.servers && !serverUrl) {
     throw new Error(`No server matching '${pathname}' path defined in OpenAPI spec`);
   }
-  pathname = removeServerURLFromPath(pathname, serverUrl);
-
-  if (openApiSpec.paths.hasOwnProperty(pathname)) {
-    return pathname;
+  const pathnameWithoutServerUrl = removeServerURLFromPath(pathname, serverUrl);
+  if (openApiSpec.paths.hasOwnProperty(pathnameWithoutServerUrl)) {
+    return pathnameWithoutServerUrl;
   }
-  const OAPaths = Object.keys(openApiSpec.paths);
-  const OAPath = findOAPathMatchingPathname(pathname, OAPaths);
-  return OAPath || pathname;
+  const OAPath = findOAPathMatchingPathname(pathnameWithoutServerUrl, openApiSpec);
+  return OAPath || pathnameWithoutServerUrl;
 }
 
-function findOAPathMatchingPathname(pathname, OAPaths) {
+function findOAPathMatchingPathname(pathname, openApiSpec) {
+  const OAPaths = Object.keys(openApiSpec.paths);
   const OAPathsWithPathParams = OAPaths.filter(path => path.includes('{'));
   const OAPath = OAPathsWithPathParams.find(OAPath => {
     const pathInColonForm = OAPath.replace(/{/g, ':').replace(/}/g, ''); // converts all {foo} to :foo
@@ -140,14 +138,14 @@ function findOAPathMatchingPathname(pathname, OAPaths) {
   return OAPath;
 }
 
-function getServerUrlUsed(openApiFullPath, servers) {
+function getServerUrlUsed(openApiPathWithServerUrl, servers) {
   if (!servers) {
     return null;
   }
-  const serverUsed = servers.find(server => openApiFullPath.startsWith(server.url));
+  const serverUsed = servers.find(server => openApiPathWithServerUrl.startsWith(server.url));
   return serverUsed ? serverUsed.url : null;
 }
 
-function removeServerURLFromPath(openApiFullPath, serverUrlUsed) {
-  return openApiFullPath.replace(serverUrlUsed, '');
+function removeServerURLFromPath(openApiPathWithServerUrl, serverUrlUsed) {
+  return openApiPathWithServerUrl.replace(serverUrlUsed, '');
 }

--- a/lib/resValidator.js
+++ b/lib/resValidator.js
@@ -25,7 +25,7 @@ const OpenAPIResponseValidator = require('openapi-response-validator').default;
 
 // In this file, 'OA' means 'Open API'
 
-module.exports = function(pathToOpenApiSpec) {
+module.exports = function (pathToOpenApiSpec) {
   const openApiSpec = parseOpenApiFile(pathToOpenApiSpec);
 
   return function (chai) {
@@ -111,7 +111,16 @@ function validateResAgainstApiSpec(res, expectedResponse, openApiSpec) {
 
 
 function getOAPath(req, openApiSpec) {
-  const pathname = url.parse(req.path).pathname; // excludes the query (because: path = pathname + query)
+  let pathname = url.parse(req.path).pathname; // excludes the query (because: path = pathname + query)
+
+  const serverUrl = getServerUrlUsed(pathname, openApiSpec.servers);
+
+  // if servers have been defined but none of the servers match the current path
+  if (openApiSpec.servers && !serverUrl) {
+    throw new Error(`No server matching '${pathname}' path defined in OpenAPI spec`);
+  }
+  pathname = removeServerURLFromPath(pathname, serverUrl);
+
   if (openApiSpec.paths.hasOwnProperty(pathname)) {
     return pathname;
   }
@@ -129,4 +138,16 @@ function findOAPathMatchingPathname(pathname, OAPaths) {
     return !!pathParamsInPathname;
   });
   return OAPath;
+}
+
+function getServerUrlUsed(openApiFullPath, servers) {
+  if (!servers) {
+    return null;
+  }
+  const serverUsed = servers.find(server => openApiFullPath.startsWith(server.url));
+  return serverUsed ? serverUsed.url : null;
+}
+
+function removeServerURLFromPath(openApiFullPath, serverUrlUsed) {
+  return openApiFullPath.replace(serverUrlUsed, '');
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-openapi-response-validator",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Simple Chai support for asserting that HTTP responses satisfy an OpenAPI spec",
   "main": "index.js",
   "scripts": {

--- a/test/exampleOpenApiFiles/valid/openapi3.json
+++ b/test/exampleOpenApiFiles/valid/openapi3.json
@@ -5,6 +5,16 @@
 		"description": "Example OpenApi 3 spec",
 		"version": "0.1.0"
 	},
+	"servers": [
+		{ 
+			"url": "/local", 
+			"description": "local"
+		},
+		{ 
+			"url": "/remote", 
+			"description": "remote"
+		}
+	],
 	"paths": {
 		"/test": {
 			"get": {

--- a/test/exampleOpenApiFiles/valid/openapi3.yml
+++ b/test/exampleOpenApiFiles/valid/openapi3.yml
@@ -3,6 +3,11 @@ info:
   title: Example OpenApi 3 spec
   description: Has various paths with responses to use in testing
   version: 0.1.0
+servers:
+  - url: /local 
+    description: local 
+  - url: /remote 
+    description: remote
 paths:
   /test/responseBody/string:
     get:

--- a/test/unit/assertions/satisfyApiSpec.test.js
+++ b/test/unit/assertions/satisfyApiSpec.test.js
@@ -35,7 +35,7 @@ for (const spec of openApiSpecs) {
   const { openApiVersion, pathToApiSpec } = spec;
 
   // add a path to a server if testing in openAPI 3
-  const serverPath = spec.openApiVersion == 3 ? '/local' : '';
+  const serverPath = openApiVersion == 3 ? '/local' : '';
 
   describe(`expect(res).to.satisfyApiSpec (using an OpenAPI ${openApiVersion} spec)`, function () {
     before(function () {
@@ -355,56 +355,6 @@ for (const spec of openApiSpecs) {
         it('fails when using .not', function () {
           const assertion = () => expect(res).to.not.satisfyApiSpec;
           expect(assertion).to.throw('No \'HEAD\' method defined for path \'/test/HTTPMethod\' in OpenAPI spec');
-        });
-      });
-    });
-    describe('OpenAPI 3 ONLY', function() {
-      before('ensure the version is OpenAPI 3', function() {
-        if (spec.openApiVersion !== 3) {
-          this.skip();
-        }
-      });
-      describe('using a different server', function () {
-        describe('the server path is defined', function() {
-          const differentServer = '/remote';
-          const res = {
-            status: 200,
-            req: {
-              method: 'GET',
-              path: `${differentServer}/test/responseBody/schemaDef`,
-            },
-            body: 'valid body (string)',
-          };
-
-          it('passes', function () {
-            expect(res).to.satisfyApiSpec;
-          });
-
-          it('fails when using .not', function () {
-            const assertion = () => expect(res).to.not.satisfyApiSpec;
-            expect(assertion).to.throw('');
-          });
-        });
-        describe('the server path is NOT defined', function() {
-          const differentServer = '/missing';
-          const res = {
-            status: 200,
-            req: {
-              method: 'GET',
-              path: `${differentServer}/test/responseBody/schemaDef`,
-            },
-            body: 'valid body (string)',
-          };
-
-          it('fails', function () {
-            const assertion = () => expect(res).to.satisfyApiSpec;
-            expect(assertion).to.throw('No server matching \'/missing/test/responseBody/schemaDef\' path defined in OpenAPI spec');
-          });
-          
-          it('fails when using .not', function () {
-            const assertion = () => expect(res).to.not.satisfyApiSpec;
-            expect(assertion).to.throw('No server matching \'/missing/test/responseBody/schemaDef\' path defined in OpenAPI spec');
-          });
         });
       });
     });

--- a/test/unit/assertions/satisfyApiSpec.test.js
+++ b/test/unit/assertions/satisfyApiSpec.test.js
@@ -33,8 +33,12 @@ const { expect } = chai;
 
 for (const spec of openApiSpecs) {
   const { openApiVersion, pathToApiSpec } = spec;
+
+  // add a path to a server if testing in openAPI 3
+  const serverPath = spec.openApiVersion == 3 ? '/local' : '';
+
   describe(`expect(res).to.satisfyApiSpec (using an OpenAPI ${openApiVersion} spec)`, function () {
-    before(function() {
+    before(function () {
       chai.use(chaiResponseValidator(pathToApiSpec));
     });
     describe('when \'res\' matches a response defined in the API spec', function () {
@@ -45,7 +49,7 @@ for (const spec of openApiSpecs) {
               status: 200,
               req: {
                 method: 'GET',
-                path: '/test/responseBody/string',
+                path: `${serverPath}/test/responseBody/string`,
               },
               body: 'valid body (string)',
             };
@@ -66,7 +70,7 @@ for (const spec of openApiSpecs) {
               status: 200,
               req: {
                 method: 'GET',
-                path: '/test/responseBody/schemaDef',
+                path: `${serverPath}/test/responseBody/schemaDef`,
               },
               body: 'valid body (string)',
             };
@@ -86,7 +90,7 @@ for (const spec of openApiSpecs) {
               status: 204,
               req: {
                 method: 'GET',
-                path: '/test/responseBody/empty',
+                path: `${serverPath}/test/responseBody/empty`,
               },
             };
 
@@ -107,7 +111,7 @@ for (const spec of openApiSpecs) {
               status: 201,
               req: {
                 method: 'GET',
-                path: '/test/multipleResponsesDefined',
+                path: `${serverPath}/test/multipleResponsesDefined`,
               },
               body: 'valid body (string)',
             };
@@ -127,7 +131,7 @@ for (const spec of openApiSpecs) {
               status: 202,
               req: {
                 method: 'GET',
-                path: '/test/multipleResponsesDefined',
+                path: `${serverPath}/test/multipleResponsesDefined`,
               },
               body: 123456, // valid body (integer)
             };
@@ -147,7 +151,7 @@ for (const spec of openApiSpecs) {
               status: 203,
               req: {
                 method: 'GET',
-                path: '/test/multipleResponsesDefined',
+                path: `${serverPath}/test/multipleResponsesDefined`,
               },
               // no body
             };
@@ -169,7 +173,7 @@ for (const spec of openApiSpecs) {
               status: 204,
               req: {
                 method: 'GET',
-                path: '/test/queryParams?exampleQueryParam=foo',
+                path: `${serverPath}/test/queryParams?exampleQueryParam=foo`,
               },
             };
 
@@ -188,7 +192,7 @@ for (const spec of openApiSpecs) {
               status: 204,
               req: {
                 method: 'GET',
-                path: `/test/queryParams?${'exampleQueryParam=foo'}&${'exampleQueryParam2=bar'}`,
+                path: `${serverPath}/test/queryParams?${'exampleQueryParam=foo'}&${'exampleQueryParam2=bar'}`,
               },
             };
 
@@ -207,7 +211,7 @@ for (const spec of openApiSpecs) {
               status: 204,
               req: {
                 method: 'GET',
-                path: '/test/pathParams/foo',
+                path: `${serverPath}/test/pathParams/foo`,
               },
             };
 
@@ -226,7 +230,7 @@ for (const spec of openApiSpecs) {
               status: 204,
               req: {
                 method: 'GET',
-                path: '/test/multiplePathParams/foo/bar',
+                path: `${serverPath}/test/multiplePathParams/foo/bar`,
               },
             };
 
@@ -245,7 +249,7 @@ for (const spec of openApiSpecs) {
               status: 204,
               req: {
                 method: 'GET',
-                path: `/test/pathAndQueryParams/${'foo'}?${'exampleQueryParam=bar'}`,
+                path: `${serverPath}/test/pathAndQueryParams/${'foo'}?${'exampleQueryParam=bar'}`,
               },
             };
 
@@ -260,14 +264,13 @@ for (const spec of openApiSpecs) {
           });
         });
       });
-
       describe('\'res\' does NOT satisfy the spec', function () {
         describe('wrong res.status', function () {
           const res = {
             status: 418,
             req: {
               method: 'GET',
-              path: '/test/responseStatus',
+              path: `${serverPath}/test/responseStatus`,
             },
           };
 
@@ -287,7 +290,7 @@ for (const spec of openApiSpecs) {
             status: 204,
             req: {
               method: 'GET',
-              path: '/test/responseBody/empty',
+              path: `${serverPath}/test/responseBody/empty`,
             },
             body: 'invalid body (should be empty)',
           };
@@ -320,7 +323,7 @@ for (const spec of openApiSpecs) {
           status: 204,
           req: {
             method: 'GET',
-            path: '/does/not/exist',
+            path: `${serverPath}/does/not/exist`,
           },
         };
 
@@ -340,7 +343,7 @@ for (const spec of openApiSpecs) {
           status: 204,
           req: {
             method: 'HEAD',
-            path: '/test/HTTPMethod',
+            path: `${serverPath}/test/HTTPMethod`,
           },
         };
 
@@ -355,6 +358,55 @@ for (const spec of openApiSpecs) {
         });
       });
     });
-  });
+    describe('OpenAPI 3 ONLY', function() {
+      before('ensure the version is OpenAPI 3', function() {
+        if (spec.openApiVersion !== 3) {
+          this.skip();
+        }
+      });
+      describe('using a different server', function () {
+        describe('the server path is defined', function() {
+          const differentServer = '/remote';
+          const res = {
+            status: 200,
+            req: {
+              method: 'GET',
+              path: `${differentServer}/test/responseBody/schemaDef`,
+            },
+            body: 'valid body (string)',
+          };
 
+          it('passes', function () {
+            expect(res).to.satisfyApiSpec;
+          });
+
+          it('fails when using .not', function () {
+            const assertion = () => expect(res).to.not.satisfyApiSpec;
+            expect(assertion).to.throw('');
+          });
+        });
+        describe('the server path is NOT defined', function() {
+          const differentServer = '/missing';
+          const res = {
+            status: 200,
+            req: {
+              method: 'GET',
+              path: `${differentServer}/test/responseBody/schemaDef`,
+            },
+            body: 'valid body (string)',
+          };
+
+          it('fails', function () {
+            const assertion = () => expect(res).to.satisfyApiSpec;
+            expect(assertion).to.throw('No server matching \'/missing/test/responseBody/schemaDef\' path defined in OpenAPI spec');
+          });
+          
+          it('fails when using .not', function () {
+            const assertion = () => expect(res).to.not.satisfyApiSpec;
+            expect(assertion).to.throw('No server matching \'/missing/test/responseBody/schemaDef\' path defined in OpenAPI spec');
+          });
+        });
+      });
+    });
+  });
 }

--- a/test/unit/assertions/usingServer.test.js
+++ b/test/unit/assertions/usingServer.test.js
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright 2019 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+const chai = require('chai');
+const path = require('path');
+
+const chaiResponseValidator = require('../../..');
+
+const pathToApiSpec = path.resolve('test/exampleOpenApiFiles/valid/openapi3.yml');
+
+const { expect } = chai;
+
+
+describe('Server tests', function () {
+  before(function () {
+    chai.use(chaiResponseValidator(pathToApiSpec));
+  });
+  describe('using a different server', function () {
+    describe('the server path is defined', function () {
+      const differentServer = '/remote';
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: `${differentServer}/test/responseBody/schemaDef`,
+        },
+        body: 'valid body (string)',
+      };
+
+      it('passes', function () {
+        expect(res).to.satisfyApiSpec;
+      });
+
+      it('fails when using .not', function () {
+        const assertion = () => expect(res).to.not.satisfyApiSpec;
+        expect(assertion).to.throw('');
+      });
+    });
+    describe('the server path is NOT defined', function () {
+      const differentServer = '/missing';
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: `${differentServer}/test/responseBody/schemaDef`,
+        },
+        body: 'valid body (string)',
+      };
+
+      it('fails', function () {
+        const assertion = () => expect(res).to.satisfyApiSpec;
+        expect(assertion).to.throw('No server matching \'/missing/test/responseBody/schemaDef\' path defined in OpenAPI spec');
+      });
+
+      it('fails when using .not', function () {
+        const assertion = () => expect(res).to.not.satisfyApiSpec;
+        expect(assertion).to.throw('No server matching \'/missing/test/responseBody/schemaDef\' path defined in OpenAPI spec');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds support and tests for multiple servers in OpenAPI 3 spec.

This has changed the tests so that some are now disabled for OpenAPI 2 specs - I'm not sure if this is the best way to do it or if there's a better solution.