### PR TITLE
Release 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-openapi-response-validator",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "Simple Chai support for asserting that HTTP responses satisfy an OpenAPI spec",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* Now support response objects from `axios`, `request-promise`, `supertest`, and `superagent` (in addition to `chai-http`) https://github.com/RuntimeTools/chai-openapi-response-validator/pull/23
* Clarify assertion failure messages https://github.com/RuntimeTools/chai-openapi-response-validator/pull/23