### PR TITLE
Release 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-openapi-response-validator",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Simple Chai support for asserting that HTTP responses satisfy an OpenAPI spec",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* Now support responses defined in your OpenAPI 2 and 3 specs that reference Response Definition Objects (e.g. `$ref: '#/components/responses/ExampleResponseDefinitionObject'`) https://github.com/RuntimeTools/chai-openapi-response-validator/pull/26