### PR TITLE
refactor: split code into OpenApiSpec classes

### DIFF
--- a/lib/classes/BaseOpenApiSpec.js
+++ b/lib/classes/BaseOpenApiSpec.js
@@ -1,0 +1,100 @@
+const url = require('url');
+const PathParser = require('path-parser').default;
+const OpenAPIResponseValidator = require('openapi-response-validator').default;
+
+class OpenApiSpec {
+  constructor(spec) {
+    this.spec = spec;
+  }
+
+  /**
+   * @returns {[PathItemObject]} [PathItemObject]
+   * @see OpenAPI2 {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#path-item-object}
+   * @see OpenAPI3 {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#pathItemObject}
+   */
+  pathsObject() {
+    return this.spec.paths;
+  }
+
+  getPathItem(openApiPath) {
+    return this.pathsObject()[openApiPath];
+  }
+
+  paths() {
+    return Object.keys(this.pathsObject());
+  }
+
+  /**
+   * @returns {ResponseObject} ResponseObject
+   * @see OpenAPI2 {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#response-object}
+   * @see OpenAPI3 {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responseObject}
+   */
+  findExpectedResponse(actualResponse) {
+    const actualRequest = actualResponse.req();
+    const expectedResponseOperation = this.findExpectedResponseOperation(actualRequest);
+
+    const status = actualResponse.status();
+    let expectedResponse = expectedResponseOperation.responses[status];
+    if (expectedResponse && expectedResponse['$ref']) {
+      expectedResponse = this.findResponseDefinition(expectedResponse['$ref']);
+    }
+    if (!expectedResponse) {
+      throw new Error(`No '${status}' response defined for endpoint '${actualRequest.method} ${this.findOpenApiPathMatchingRequest(actualRequest)}' in OpenAPI spec`);
+    }
+
+    return { [status]: expectedResponse };
+  }
+
+  findOpenApiPathMatchingRequest(actualRequest) {
+    const actualPathname = this.extractCleanPathname(actualRequest);
+    const openApiPath = this.findOpenApiPathMatchingPathname(actualPathname);
+    return openApiPath;
+  }
+
+  extractCleanPathname(actualRequest) {
+    const { pathname } = url.parse(actualRequest.path); // excludes the query (because: path = pathname + query)
+    return this.cleanPathname(pathname);
+  }
+
+  findOpenApiPathMatchingPathname(pathname) {
+    const openApiPath = this.paths().find(openApiPath => {
+      const pathInColonForm = openApiPath.replace(/{/g, ':').replace(/}/g, ''); // converts all {foo} to :foo
+      const pathParser = new PathParser(pathInColonForm);
+      const pathParamsInPathname = pathParser.test(pathname); // => one of: null, {}, {exampleParam: 'foo'}
+      return !!pathParamsInPathname;
+    });
+    return openApiPath;
+  }
+
+  /**
+   * @returns {OperationObject} OperationObject
+   * @see OpenAPI2 {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#operation-object}
+   * @see OpenAPI3 {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#operationObject}
+   */
+  findExpectedResponseOperation(actualRequest) {
+    const actualPathname = this.extractCleanPathname(actualRequest);
+    const openApiPath = this.findOpenApiPathMatchingPathname(actualPathname);
+    if (!openApiPath) {
+      throw new Error(`No '${actualPathname}' path defined in OpenAPI spec`);
+    }
+    const pathItemObject = this.getPathItem(openApiPath);
+    const operationObject = pathItemObject[actualRequest.method.toLowerCase()];
+    if (!operationObject) {
+      throw new Error(`No '${actualRequest.method}' method defined for path '${openApiPath}' in OpenAPI spec`);
+    }
+    return operationObject;
+  }
+
+  validateResponse(actualResponse, expectedResponse) {
+    const resValidator = new OpenAPIResponseValidator({
+      responses: expectedResponse,
+      ...this.getVersionSpecificValidatorOptions(),
+    });
+
+    const [expectedResStatus] = Object.keys(expectedResponse);
+    const validationError = resValidator.validateResponse(expectedResStatus, actualResponse.body());
+    return validationError;
+  }
+}
+
+module.exports = OpenApiSpec;

--- a/lib/classes/OpenApi2Spec.js
+++ b/lib/classes/OpenApi2Spec.js
@@ -1,0 +1,24 @@
+const OpenApiSpec = require('./BaseOpenApiSpec');
+
+class OpenApi2Spec extends OpenApiSpec {
+  cleanPathname(pathname) {
+    return pathname;
+  }
+
+  /**
+   * @returns {ResponseObject} ResponseObject {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#responses-definitions-object}
+   */
+  findResponseDefinition(referenceString) {
+    const nameOfResponseDefinition = referenceString.split('#/responses/')[1];
+    return this.spec.responses[nameOfResponseDefinition];
+  }
+
+  /**
+   * @see DefinitionsObject {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#definitions-object}
+   */
+  getVersionSpecificValidatorOptions() {
+    return { definitions: this.spec.definitions };
+  }
+}
+
+module.exports = OpenApi2Spec;

--- a/lib/classes/OpenApi3Spec.js
+++ b/lib/classes/OpenApi3Spec.js
@@ -1,0 +1,40 @@
+const OpenApiSpec = require('./BaseOpenApiSpec');
+
+class OpenApi3Spec extends OpenApiSpec {
+  /**
+   * @returns {[ServerObject]} [ServerObject] {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#server-object}
+   */
+  servers() {
+    return this.spec.servers;
+  }
+
+  findMatchingServer(pathname) {
+    const matchingServer = this.servers().find(server => pathname.startsWith(server.url));
+    if (!matchingServer) {
+      throw new Error(`No server matching '${pathname}' path defined in OpenAPI spec`);
+    }
+    return matchingServer;
+  }
+
+  cleanPathname(pathname) {
+    const serverUsed = this.findMatchingServer(pathname);
+    return pathname.replace(serverUsed.url, '');
+  }
+
+  /**
+   * @returns {ResponseObject} ResponseObject {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsResponses}
+   */
+  findResponseDefinition(referenceString) {
+    const nameOfResponseDefinition = referenceString.split('#/components/responses/')[1];
+    return this.spec.components.responses[nameOfResponseDefinition];
+  }
+
+  /**
+   * @see ComponentsObject {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsObject}
+   */
+  getVersionSpecificValidatorOptions() {
+    return { components: this.spec.components };
+  }
+}
+
+module.exports = OpenApi3Spec;

--- a/lib/classes/Response.js
+++ b/lib/classes/Response.js
@@ -1,4 +1,4 @@
-const utils = require('./utils');
+const utils = require('../utils');
 
 class Response {
   constructor(res) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,32 +14,23 @@
  * limitations under the License.
  *******************************************************************************/
 
-const fs = require('fs-extra');
-const yaml = require('js-yaml');
-const FilePath = require('path');
-const url = require('url');
-const PathParser = require('path-parser').default;
-const OpenAPISchemaValidator = require('openapi-schema-validator').default;
-const OpenAPIResponseValidator = require('openapi-response-validator').default;
-
 const utils = require('./utils');
-const Response = require('./Response');
-
-// In this file, 'OA' means 'Open API'
+const Response = require('./classes/Response');
+const openApiSpecFactory = require('./openApiSpecFactory');
 
 module.exports = function (pathToOpenApiSpec) {
-  const openApiSpec = parseOpenApiFile(pathToOpenApiSpec);
+  const openApiSpec = openApiSpecFactory.makeApiSpec(pathToOpenApiSpec);
 
   return function (chai) {
-    const Assertion = chai.Assertion;
+    const { Assertion } = chai;
 
     Assertion.addProperty('satisfyApiSpec', function () {
       const actualResponse = new Response(this._obj);
       const actualRequest = actualResponse.req();
 
-      const expectedResponse = findResponseObjDefinedInApiSpec(actualResponse, openApiSpec);
+      const expectedResponse = openApiSpec.findExpectedResponse(actualResponse);
 
-      const validationError = validateResAgainstApiSpec(actualResponse, expectedResponse, openApiSpec);
+      const validationError = openApiSpec.validateResponse(actualResponse, expectedResponse);
       if (validationError) {
         validationError.actualResponse = actualResponse.summary();
       }
@@ -47,125 +38,10 @@ module.exports = function (pathToOpenApiSpec) {
       this.assert(
         !validationError,
         `expected res to satisfy API spec:\n${utils.stringify(validationError)}`,
-        `expected res not to satisfy API spec for '${actualResponse.status()}' response defined for endpoint '${actualRequest.method} ${getOAPath(actualRequest, openApiSpec)}' in OpenAPI spec\nres: ${actualResponse.toString()}`,
+        `expected res not to satisfy API spec for '${actualResponse.status()}' response`
+          + ` defined for endpoint '${actualRequest.method} ${openApiSpec.findOpenApiPathMatchingRequest(actualRequest)}'`
+          + ` in OpenAPI spec\nres: ${actualResponse.toString()}`,
       );
     });
   };
 };
-
-function parseOpenApiFile(filePath) {
-  if (!FilePath.isAbsolute(filePath)) {
-    throw new Error('The "path" argument must be an absolute filepath');
-  }
-  const fileData = fs.readFileSync(filePath);
-  let openApiSpec;
-  try {
-    openApiSpec = yaml.safeLoad(fileData);
-  } catch (error) {
-    throw new Error(`Unable to read the specified OpenAPI document. File is invalid YAML or JSON:\n${error.message}`);
-  }
-
-  try {
-    const validator = new OpenAPISchemaValidator({ version: getOAVersion(openApiSpec) });
-    const { errors } = validator.validate(openApiSpec);
-    if (errors.length > 0) {
-      throw new Error(utils.stringify(errors));
-    }
-  } catch (error) {
-    throw new Error(`File is not a valid OpenAPI spec.\nError(s): ${error.message}`);
-  }
-
-  return openApiSpec;
-}
-
-function getOAVersion(openApiSpec) {
-  return openApiSpec.swagger || openApiSpec.openapi;
-}
-
-function findResponseObjDefinedInApiSpec(actualResponse, openApiSpec) {
-  const actualRequest = actualResponse.req();
-  const openApiPath = getOAPath(actualRequest, openApiSpec);
-  const pathItemObject = openApiSpec.paths[openApiPath];
-  if (!pathItemObject) {
-    throw new Error(`No '${openApiPath}' path defined in OpenAPI spec`);
-  }
-
-  const httpMethod = actualRequest.method;
-  const operationObject = pathItemObject[httpMethod.toLowerCase()];
-  if (!operationObject) {
-    throw new Error(`No '${actualRequest.method}' method defined for path '${openApiPath}' in OpenAPI spec`);
-  }
-
-  const status = actualResponse.status();
-  let expectedResponse = operationObject.responses[status];
-  if (expectedResponse && expectedResponse['$ref']) {
-    expectedResponse = findResponseDefinitionObject(expectedResponse['$ref'], openApiSpec);
-  }
-  if (!expectedResponse) {
-    throw new Error(`No '${status}' response defined for endpoint '${httpMethod} ${openApiPath}' in OpenAPI spec`);
-  }
-
-  return { [status]: expectedResponse };
-}
-
-function findResponseDefinitionObject(referenceString, openApiSpec) {
-  try { // OpenAPI 3
-    const nameOfReferencedResponseDefinition = referenceString.split('#/components/responses/')[1];
-    return openApiSpec.components.responses[nameOfReferencedResponseDefinition];
-  } catch (error) { // OpenAPI 2
-    const nameOfReferencedResponseDefinition = referenceString.split('#/responses/')[1];
-    return openApiSpec.responses[nameOfReferencedResponseDefinition];
-  }
-}
-
-function validateResAgainstApiSpec(actualResponse, expectedResponse, openApiSpec) {
-  const resValidator = new OpenAPIResponseValidator({
-    responses: expectedResponse,
-    components: openApiSpec.components, // needed if openApiSpec is OpenAPI 3
-    definitions: openApiSpec.definitions, // needed if openApiSpec is OpenAPI 2
-  });
-
-  const [expectedResStatus] = Object.keys(expectedResponse);
-  const validationError = resValidator.validateResponse(expectedResStatus, actualResponse.body());
-  return validationError;
-}
-
-function getOAPath(actualRequest, openApiSpec) {
-  const pathname = url.parse(actualRequest.path).pathname; // excludes the query (because: path = pathname + query)
-
-  // needed if openApiSpec is OpenAPI 3
-  const serverUrl = getServerUrlUsed(pathname, openApiSpec.servers);
-  // if servers have been defined but none of the servers match the current path
-  if (openApiSpec.servers && !serverUrl) {
-    throw new Error(`No server matching '${pathname}' path defined in OpenAPI spec`);
-  }
-
-  const pathnameWithoutServerUrl = removeServerURLFromPath(pathname, serverUrl);
-  const OAPath = findOAPathMatchingPathname(pathnameWithoutServerUrl, openApiSpec);
-  return OAPath || pathnameWithoutServerUrl;
-}
-
-function findOAPathMatchingPathname(pathname, openApiSpec) {
-  const OAPaths = Object.keys(openApiSpec.paths);
-  const OAPath = OAPaths.find(OAPath => {
-    const pathInColonForm = OAPath.replace(/{/g, ':').replace(/}/g, ''); // converts all {foo} to :foo
-    const pathParser = new PathParser(pathInColonForm);
-    const pathParamsInPathname = pathParser.test(pathname);
-    return !!pathParamsInPathname;
-  });
-  return OAPath;
-}
-
-// for OpenAPI 3
-function getServerUrlUsed(openApiPathWithServerUrl, servers) {
-  if (!servers) {
-    return null;
-  }
-  const serverUsed = servers.find(server => openApiPathWithServerUrl.startsWith(server.url));
-  return serverUsed ? serverUsed.url : null;
-}
-
-// for OpenAPI 3
-function removeServerURLFromPath(openApiPathWithServerUrl, serverUrlUsed) {
-  return openApiPathWithServerUrl.replace(serverUrlUsed, '');
-}

--- a/lib/openApiSpecFactory.js
+++ b/lib/openApiSpecFactory.js
@@ -1,0 +1,53 @@
+const fs = require('fs-extra');
+const yaml = require('js-yaml');
+const path = require('path');
+const OpenAPISchemaValidator = require('openapi-schema-validator').default;
+
+const utils = require('./utils');
+const OpenApi2Spec = require('./classes/OpenApi2Spec');
+const OpenApi3Spec = require('./classes/OpenApi3Spec');
+
+function makeApiSpec(filepath) {
+  const spec = loadFile(filepath);
+  validateSpec(spec);
+  if (getOpenApiVersion(spec) === '2.0') {
+    return new OpenApi2Spec(spec);
+  }
+  // if (getOpenApiVersion(spec).startsWith('3.'))
+  return new OpenApi3Spec(spec);
+}
+
+function loadFile(filepath) {
+  if (!path.isAbsolute(filepath)) {
+    throw new Error('The "path" argument must be an absolute filepath');
+  }
+  const fileData = fs.readFileSync(filepath);
+  try {
+    return yaml.safeLoad(fileData);
+  } catch (error) {
+    throw new Error(`Unable to read the specified OpenAPI document. File is invalid YAML or JSON:\n${error.message}`);
+  }
+}
+
+function validateSpec(spec) {
+  try {
+    const validator = new OpenAPISchemaValidator({ version: getOpenApiVersion(spec) });
+    const { errors } = validator.validate(spec);
+    if (errors.length > 0) {
+      throw new Error(utils.stringify(errors));
+    }
+  } catch (error) {
+    throw new Error(`File is not a valid OpenAPI spec.\nError(s): ${error.message}`);
+  }
+
+}
+
+function getOpenApiVersion(openApiSpec) {
+  return openApiSpec.swagger // '2.0'
+   || openApiSpec.openapi; // '3.X.X'
+}
+
+
+module.exports = {
+  makeApiSpec,
+};

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -29,7 +29,7 @@ module.exports = function(config) {
     transpilers: [],
     testFramework: 'mocha',
     coverageAnalysis: 'perTest',
-    thresholds: { high: 100, low: 96, break: 90 },
+    thresholds: { high: 100, low: 99, break: 95 },
     maxConcurrentTestRunners: 2, // resolves issue with tests not completing. See: https://github.com/stryker-mutator/stryker/issues/1542#issuecomment-495477158
   });
 };


### PR DESCRIPTION
Makes code clearer and easier to maintain/extend
* use `OpenApiSpec` classes instead of pure functions
* put code unique to OpenAPI 2 in new `OpenApi2Spec` class, and same for OpenAPI 3
* add links to official OpenAPI docs
* increase strictness of mutation testing