### PR TITLE
User can define complex relative and absolute servers in OpenAPI 3 spec

### DIFF
--- a/lib/classes/BaseOpenApiSpec.js
+++ b/lib/classes/BaseOpenApiSpec.js
@@ -1,6 +1,6 @@
-const url = require('url');
-const PathParser = require('path-parser').default;
 const OpenAPIResponseValidator = require('openapi-response-validator').default;
+
+const { extractPathname } = require('./Response');
 
 class OpenApiSpec {
   constructor(spec) {
@@ -46,23 +46,8 @@ class OpenApiSpec {
   }
 
   findOpenApiPathMatchingRequest(actualRequest) {
-    const actualPathname = this.extractCleanPathname(actualRequest);
+    const actualPathname = extractPathname(actualRequest);
     const openApiPath = this.findOpenApiPathMatchingPathname(actualPathname);
-    return openApiPath;
-  }
-
-  extractCleanPathname(actualRequest) {
-    const { pathname } = url.parse(actualRequest.path); // excludes the query (because: path = pathname + query)
-    return this.cleanPathname(pathname);
-  }
-
-  findOpenApiPathMatchingPathname(pathname) {
-    const openApiPath = this.paths().find(openApiPath => {
-      const pathInColonForm = openApiPath.replace(/{/g, ':').replace(/}/g, ''); // converts all {foo} to :foo
-      const pathParser = new PathParser(pathInColonForm);
-      const pathParamsInPathname = pathParser.test(pathname); // => one of: null, {}, {exampleParam: 'foo'}
-      return !!pathParamsInPathname;
-    });
     return openApiPath;
   }
 
@@ -72,11 +57,8 @@ class OpenApiSpec {
    * @see OpenAPI3 {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#operationObject}
    */
   findExpectedResponseOperation(actualRequest) {
-    const actualPathname = this.extractCleanPathname(actualRequest);
+    const actualPathname = extractPathname(actualRequest);
     const openApiPath = this.findOpenApiPathMatchingPathname(actualPathname);
-    if (!openApiPath) {
-      throw new Error(`No '${actualPathname}' path defined in OpenAPI spec`);
-    }
     const pathItemObject = this.getPathItem(openApiPath);
     const operationObject = pathItemObject[actualRequest.method.toLowerCase()];
     if (!operationObject) {

--- a/lib/classes/OpenApi2Spec.js
+++ b/lib/classes/OpenApi2Spec.js
@@ -1,8 +1,19 @@
+const PathParser = require('path-parser').default;
+
 const OpenApiSpec = require('./BaseOpenApiSpec');
 
 class OpenApi2Spec extends OpenApiSpec {
-  cleanPathname(pathname) {
-    return pathname;
+  findOpenApiPathMatchingPathname(pathname) {
+    const openApiPath = this.paths().find(openApiPath => {
+      const pathInColonForm = openApiPath.replace(/{/g, ':').replace(/}/g, ''); // converts all {foo} to :foo
+      const pathParser = new PathParser(pathInColonForm);
+      const pathParamsInPathname = pathParser.test(pathname); // => one of: null, {}, {exampleParam: 'foo'}
+      return !!pathParamsInPathname;
+    });
+    if (!openApiPath) {
+      throw new Error(`No '${pathname}' path defined in OpenAPI spec`);
+    }
+    return openApiPath;
   }
 
   /**

--- a/lib/classes/OpenApi3Spec.js
+++ b/lib/classes/OpenApi3Spec.js
@@ -1,6 +1,27 @@
+const util = require('util');
+const PathParser = require('path-parser').default;
+
 const OpenApiSpec = require('./BaseOpenApiSpec');
 
+const serversPropNotProvidedOrIsEmptyArray = (spec) =>
+  (!spec.hasOwnProperty('servers') || !spec.servers.length);
+
 class OpenApi3Spec extends OpenApiSpec {
+  constructor(spec) {
+    super(spec);
+    this.ensureDefaultServer();
+  }
+
+  /**
+   * "If the servers property is not provided, or is an empty array, the default value would be a Server Object with a url value of '/'"
+   * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#fixed-fields
+   */
+  ensureDefaultServer() {
+    if (serversPropNotProvidedOrIsEmptyArray(this.spec)) {
+      this.spec.servers = [{ url: '/' }];
+    }
+  }
+
   /**
    * @returns {[ServerObject]} [ServerObject] {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#server-object}
    */
@@ -8,17 +29,32 @@ class OpenApi3Spec extends OpenApiSpec {
     return this.spec.servers;
   }
 
-  findMatchingServer(pathname) {
-    const matchingServer = this.servers().find(server => pathname.startsWith(server.url));
-    if (!matchingServer) {
+  findMatchingServerUrls(pathname) {
+    const matchingServers = this.servers().filter(server => pathname.startsWith(server.url));
+    if (!matchingServers.length) {
       throw new Error(`No server matching '${pathname}' path defined in OpenAPI spec`);
     }
-    return matchingServer;
+    const matchingServerUrls = matchingServers.map(server => server.url);
+    return matchingServerUrls;
   }
 
-  cleanPathname(pathname) {
-    const serverUsed = this.findMatchingServer(pathname);
-    return pathname.replace(serverUsed.url, '');
+  findOpenApiPathMatchingPathname(pathname) {
+    const matchingServerUrls = this.findMatchingServerUrls(pathname);
+    const openApiPath = this.paths().find(openApiPath => {
+      const pathInColonForm = openApiPath.replace(/{/g, ':').replace(/}/g, ''); // converts all {foo} to :foo
+      const pathParser = new PathParser(pathInColonForm);
+      for (const serverUrl of matchingServerUrls) {
+        const pathnameWithoutServerUrl = serverUrl === '/' ? pathname : pathname.replace(serverUrl, '');
+        const pathParamsInPathname = pathParser.test(pathnameWithoutServerUrl); // => one of: null, {}, {exampleParam: 'foo'}
+        if (pathParamsInPathname) {
+          return true;
+        }
+      }
+    });
+    if (!openApiPath) {
+      throw new Error(`No '${pathname}' path defined in OpenAPI spec. (Matches servers ${util.inspect(matchingServerUrls)} but no 'serverUrl/endpointPath' combinations)`);
+    }
+    return openApiPath;
   }
 
   /**

--- a/lib/classes/OpenApi3Spec.js
+++ b/lib/classes/OpenApi3Spec.js
@@ -1,10 +1,13 @@
-const util = require('util');
+const { inspect } = require('util');
+const url = require('url');
 const PathParser = require('path-parser').default;
 
 const OpenApiSpec = require('./BaseOpenApiSpec');
 
 const serversPropNotProvidedOrIsEmptyArray = (spec) =>
   (!spec.hasOwnProperty('servers') || !spec.servers.length);
+
+const extractBasePath = (inputUrl) => url.parse(inputUrl).path;
 
 class OpenApi3Spec extends OpenApiSpec {
   constructor(spec) {
@@ -29,30 +32,48 @@ class OpenApi3Spec extends OpenApiSpec {
     return this.spec.servers;
   }
 
-  findMatchingServerUrls(pathname) {
-    const matchingServers = this.servers().filter(server => pathname.startsWith(server.url));
-    if (!matchingServers.length) {
-      throw new Error(`No server matching '${pathname}' path defined in OpenAPI spec`);
-    }
-    const matchingServerUrls = matchingServers.map(server => server.url);
+  getServerUrls() {
+    return this.servers().map(server => server.url);
+  }
+
+  getServerBasePaths() {
+    const basePaths = this.servers().map(server => extractBasePath(server.url));
+    return basePaths;
+  }
+
+  getMatchingServerUrls(pathname) {
+    const matchingServerUrls = this.getServerUrls()
+      .filter(url => pathname.startsWith(extractBasePath(url)));
     return matchingServerUrls;
   }
 
+  getMatchingServerBasePaths(pathname) {
+    const matchingServerBasePaths = this.getServerBasePaths()
+      .filter(basePath => pathname.startsWith(basePath));
+    return matchingServerBasePaths;
+  }
+
   findOpenApiPathMatchingPathname(pathname) {
-    const matchingServerUrls = this.findMatchingServerUrls(pathname);
+    const matchingServerBasePaths = this.getMatchingServerBasePaths(pathname);
+    if (!matchingServerBasePaths.length) {
+      throw new Error(`No server matching '${pathname}' path defined in OpenAPI spec`);
+    }
     const openApiPath = this.paths().find(openApiPath => {
       const pathInColonForm = openApiPath.replace(/{/g, ':').replace(/}/g, ''); // converts all {foo} to :foo
       const pathParser = new PathParser(pathInColonForm);
-      for (const serverUrl of matchingServerUrls) {
-        const pathnameWithoutServerUrl = serverUrl === '/' ? pathname : pathname.replace(serverUrl, '');
-        const pathParamsInPathname = pathParser.test(pathnameWithoutServerUrl); // => one of: null, {}, {exampleParam: 'foo'}
+      for (const basePath of matchingServerBasePaths) {
+        const pathnameWithoutServerBasePath = (basePath === '/')
+          ? pathname
+          : pathname.replace(basePath, '');
+        const pathParamsInPathname = pathParser.test(pathnameWithoutServerBasePath); // => one of: null, {}, {exampleParam: 'foo'}
         if (pathParamsInPathname) {
           return true;
         }
       }
     });
     if (!openApiPath) {
-      throw new Error(`No '${pathname}' path defined in OpenAPI spec. (Matches servers ${util.inspect(matchingServerUrls)} but no 'serverUrl/endpointPath' combinations)`);
+      const matchingServerUrls = this.getMatchingServerUrls(pathname);
+      throw new Error(`No '${pathname}' path defined in OpenAPI spec. (Matches servers ${inspect(matchingServerUrls)} but no 'server/endpointPath' combinations)`);
     }
     return openApiPath;
   }

--- a/lib/classes/Response.js
+++ b/lib/classes/Response.js
@@ -1,3 +1,5 @@
+const url = require('url');
+
 const utils = require('../utils');
 
 class Response {
@@ -42,4 +44,10 @@ class Response {
   }
 }
 
+const extractPathname = (actualRequest) => {
+  const { pathname } = url.parse(actualRequest.path); // excludes the query (because: path = pathname + query)
+  return pathname;
+};
+
 module.exports = Response;
+module.exports.extractPathname = extractPathname;

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -29,7 +29,7 @@ module.exports = function(config) {
     transpilers: [],
     testFramework: 'mocha',
     coverageAnalysis: 'perTest',
-    thresholds: { high: 100, low: 99, break: 95 },
+    thresholds: { high: 100, low: 99, break: 99 },
     maxConcurrentTestRunners: 2, // resolves issue with tests not completing. See: https://github.com/stryker-mutator/stryker/issues/1542#issuecomment-495477158
   });
 };

--- a/test/resources/exampleOpenApiFiles/valid/serversDefinedDifferently/noServersProperty.yml
+++ b/test/resources/exampleOpenApiFiles/valid/serversDefinedDifferently/noServersProperty.yml
@@ -1,0 +1,15 @@
+openapi: 3.0.0
+info:
+  title: Example OpenApi 3 spec
+  description: Has no 'servers' property
+  version: 0.1.0
+paths:
+  /test/responseBody/string:
+    get:
+      responses:
+        200:
+          description: Response body should be a string
+          content:
+            application/json:
+              schema:
+                type: string

--- a/test/resources/exampleOpenApiFiles/valid/serversDefinedDifferently/noServersWithBasePaths.yml
+++ b/test/resources/exampleOpenApiFiles/valid/serversDefinedDifferently/noServersWithBasePaths.yml
@@ -1,0 +1,18 @@
+openapi: 3.0.0
+info:
+  title: Example OpenApi 3 spec
+  description: This spec does not define a server with a base path
+  version: 0.1.0
+servers:
+  - url: http://api.example.com
+    description: absolute server without a base path
+paths:
+  /test/responseBody/string:
+    get:
+      responses:
+        200:
+          description: Response body should be a string
+          content:
+            application/json:
+              schema:
+                type: string

--- a/test/resources/exampleOpenApiFiles/valid/serversDefinedDifferently/onlyAbsoluteServersWithBasePaths.yml
+++ b/test/resources/exampleOpenApiFiles/valid/serversDefinedDifferently/onlyAbsoluteServersWithBasePaths.yml
@@ -1,0 +1,18 @@
+openapi: 3.0.0
+info:
+  title: Example OpenApi 3 spec
+  description: Has an absolute server with a base path
+  version: 0.1.0
+servers:
+  - url: http://api.example.com/basePath1
+    description: absolute server with a base path
+paths:
+  /test/responseBody/string:
+    get:
+      responses:
+        200:
+          description: Response body should be a string
+          content:
+            application/json:
+              schema:
+                type: string

--- a/test/resources/exampleOpenApiFiles/valid/serversDefinedDifferently/serversIsEmptyArray.yml
+++ b/test/resources/exampleOpenApiFiles/valid/serversDefinedDifferently/serversIsEmptyArray.yml
@@ -1,0 +1,16 @@
+openapi: 3.0.0
+info:
+  title: Example OpenApi 3 spec
+  description: \'servers' is an empty array
+  version: 0.1.0
+servers: []
+paths:
+  /test/responseBody/string:
+    get:
+      responses:
+        200:
+          description: Response body should be a string
+          content:
+            application/json:
+              schema:
+                type: string

--- a/test/resources/exampleOpenApiFiles/valid/serversDefinedDifferently/variousServers.yml
+++ b/test/resources/exampleOpenApiFiles/valid/serversDefinedDifferently/variousServers.yml
@@ -1,17 +1,29 @@
 openapi: 3.0.0
 info:
   title: Example OpenApi 3 spec
-  description: Has various paths with responses to use in testing
+  description: Has various server urls
   version: 0.1.0
 servers:
-  - url: /
-    description: default server url
   - url: /relativeServer
     description: relative server url
   - url: /differentRelativeServer
     description: different relative server url
   - url: /relativeServer2
     description: pathnames that match this will also match 'relativeServer'
+  - url: http://api.example.com/basePath1
+    description: different scheme (http)
+  - url: https://api.example.com/basePath2
+    description: different scheme (https)
+  - url: ws://api.example.com/basePath3
+    description: different scheme (ws)
+  - url: wss://api.example.com/basePath4
+    description: different scheme (wss)
+  - url: http://api.example.com:8443/basePath5
+    description: with port
+  - url: http://localhost:3025/basePath6
+    description: different host (localhost)
+  - url: http://10.0.81.36/basePath7
+    description: different host (IPv4)
 paths:
   /test/responseBody/string:
     get:

--- a/test/resources/exampleOpenApiFiles/valid/serversDefinedDifferently/variousServers.yml
+++ b/test/resources/exampleOpenApiFiles/valid/serversDefinedDifferently/variousServers.yml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  title: Example OpenApi 3 spec
+  description: Has various paths with responses to use in testing
+  version: 0.1.0
+servers:
+  - url: /
+    description: default server url
+  - url: /relativeServer
+    description: relative server url
+  - url: /differentRelativeServer
+    description: different relative server url
+  - url: /relativeServer2
+    description: pathnames that match this will also match 'relativeServer'
+paths:
+  /test/responseBody/string:
+    get:
+      responses:
+        200:
+          description: Response body should be a string
+          content:
+            application/json:
+              schema:
+                type: string

--- a/test/unit/assertions/definedServerPath.test.js
+++ b/test/unit/assertions/definedServerPath.test.js
@@ -16,53 +16,256 @@
 
 const chai = require('chai');
 const path = require('path');
+const util = require('util');
 
 const chaiResponseValidator = require('../../..');
 
-const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/valid/openapi3.yml');
-chai.use(chaiResponseValidator(pathToApiSpec));
+const dirContainingApiSpec = path.resolve('test/resources/exampleOpenApiFiles/valid/serversDefinedDifferently');
 const { expect } = chai;
 
-describe('Using an OA3 spec that defines server paths', function () {
-  describe('res.req.path matches a defined server path', function () {
-    const differentServer = '/remote';
-    const res = {
-      status: 200,
-      req: {
-        method: 'GET',
-        path: `${differentServer}/test/responseBody/string`,
-      },
-      body: 'valid body (string)',
-    };
+describe('Using OpenAPI 3 specs that define servers differently', function () {
 
-    it('passes', function () {
-      expect(res).to.satisfyApiSpec;
+  describe('spec has no server property', function() {
+
+    before(function () {
+      const pathToApiSpec = path.join(dirContainingApiSpec, 'noServersProperty.yml');
+      chai.use(chaiResponseValidator(pathToApiSpec));
     });
 
-    it('fails when using .not', function () {
-      const assertion = () => expect(res).to.not.satisfyApiSpec;
-      expect(assertion).to.throw('');
+    describe('res.req.path matches the default server (\'/\') and an endpoint path', function () {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: '/test/responseBody/string',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('passes', function () {
+        expect(res).to.satisfyApiSpec;
+      });
+
+      it('fails when using .not', function () {
+        const assertion = () => expect(res).to.not.satisfyApiSpec;
+        expect(assertion).to.throw('');
+      });
+    });
+    describe('res.req.path does not match any servers', function () {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: 'nonExistentServer/test/responseBody/string',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('fails', function () {
+        const assertion = () => expect(res).to.satisfyApiSpec;
+        expect(assertion).to.throw('No server matching \'nonExistentServer/test/responseBody/string\' path defined in OpenAPI spec');
+      });
+
+      it('fails when using .not', function () {
+        const assertion = () => expect(res).to.not.satisfyApiSpec;
+        expect(assertion).to.throw('No server matching \'nonExistentServer/test/responseBody/string\' path defined in OpenAPI spec');
+      });
+    });
+    describe('res.req.path matches the default server (\'/\') but no endpoint paths', function () {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: '/nonExistentEndpointPath',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('fails', function () {
+        const assertion = () => expect(res).to.satisfyApiSpec;
+        expect(assertion).to.throw(`No '/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${util.inspect(['/'])} but no 'serverUrl/endpointPath' combinations)`);
+      });
+
+      it('fails when using .not', function () {
+        const assertion = () => expect(res).to.not.satisfyApiSpec;
+        expect(assertion).to.throw(`No '/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${util.inspect(['/'])} but no 'serverUrl/endpointPath' combinations)`);
+      });
     });
   });
-  describe('res.req.path does not match a defined server path', function () {
-    const differentServer = '/missing';
-    const res = {
-      status: 200,
-      req: {
-        method: 'GET',
-        path: `${differentServer}/test/responseBody/string`,
+
+  describe('spec\'s server property is an empty array', function() {
+
+    before(function () {
+      const pathToApiSpec = path.join(dirContainingApiSpec, 'serversIsEmptyArray.yml');
+      chai.use(chaiResponseValidator(pathToApiSpec));
+    });
+
+    describe('res.req.path matches the default server (\'/\') and an endpoint path', function () {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: '/test/responseBody/string',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('passes', function () {
+        expect(res).to.satisfyApiSpec;
+      });
+
+      it('fails when using .not', function () {
+        const assertion = () => expect(res).to.not.satisfyApiSpec;
+        expect(assertion).to.throw('');
+      });
+    });
+    describe('res.req.path does not match any servers', function () {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: 'nonExistentServer/test/responseBody/string',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('fails', function () {
+        const assertion = () => expect(res).to.satisfyApiSpec;
+        expect(assertion).to.throw('No server matching \'nonExistentServer/test/responseBody/string\' path defined in OpenAPI spec');
+      });
+
+      it('fails when using .not', function () {
+        const assertion = () => expect(res).to.not.satisfyApiSpec;
+        expect(assertion).to.throw('No server matching \'nonExistentServer/test/responseBody/string\' path defined in OpenAPI spec');
+      });
+    });
+    describe('res.req.path matches the default server (\'/\') but no endpoint paths', function () {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: '/nonExistentEndpointPath',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('fails', function () {
+        const assertion = () => expect(res).to.satisfyApiSpec;
+        expect(assertion).to.throw(`No '/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${util.inspect(['/'])} but no 'serverUrl/endpointPath' combinations)`);
+      });
+
+      it('fails when using .not', function () {
+        const assertion = () => expect(res).to.not.satisfyApiSpec;
+        expect(assertion).to.throw(`No '/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${util.inspect(['/'])} but no 'serverUrl/endpointPath' combinations)`);
+      });
+    });
+  });
+
+  describe('spec\'s server property is an array of servers', function() {
+    const tests = {
+      'default server url (\'/\')': {
+        serverUrl: '',
+        expectedMatchingServers: [
+          '/',
+        ],
       },
-      body: 'valid body (string)',
+      'relative server url': {
+        serverUrl: '/relativeServer',
+        expectedMatchingServers: [
+          '/',
+          '/relativeServer',
+        ],
+      },
+      'different relative server url': {
+        serverUrl: '/differentRelativeServer',
+        expectedMatchingServers: [
+          '/',
+          '/differentRelativeServer',
+        ],
+      },
+      'multiple relative server urls': {
+        serverUrl: '/relativeServer2',
+        expectedMatchingServers: [
+          '/',
+          '/relativeServer',
+          '/relativeServer2',
+        ],
+      },
     };
 
-    it('fails', function () {
-      const assertion = () => expect(res).to.satisfyApiSpec;
-      expect(assertion).to.throw('No server matching \'/missing/test/responseBody/string\' path defined in OpenAPI spec');
-    });
+    for (const [testName, test] of Object.entries(tests)) {
+      describe(`res.req.path contains a ${testName}`, function() {
 
-    it('fails when using .not', function () {
-      const assertion = () => expect(res).to.not.satisfyApiSpec;
-      expect(assertion).to.throw('No server matching \'/missing/test/responseBody/string\' path defined in OpenAPI spec');
-    });
+        const {
+          serverUrl,
+          expectedMatchingServers,
+        } = test;
+
+        before(function () {
+          const pathToApiSpec = path.join(dirContainingApiSpec, 'variousServers.yml');
+          chai.use(chaiResponseValidator(pathToApiSpec));
+        });
+
+        describe(`res.req.path matches a server ('${serverUrl}') and an endpoint path`, function () {
+          const res = {
+            status: 200,
+            req: {
+              method: 'GET',
+              path: `${serverUrl}/test/responseBody/string`,
+            },
+            body: 'valid body (string)',
+          };
+
+          it('passes', function () {
+            expect(res).to.satisfyApiSpec;
+          });
+
+          it('fails when using .not', function () {
+            const assertion = () => expect(res).to.not.satisfyApiSpec;
+            expect(assertion).to.throw('');
+          });
+        });
+        describe('res.req.path does not match any servers', function () {
+          const res = {
+            status: 200,
+            req: {
+              method: 'GET',
+              path: 'nonExistentServer/test/responseBody/string',
+            },
+            body: 'valid body (string)',
+          };
+
+          it('fails', function () {
+            const assertion = () => expect(res).to.satisfyApiSpec;
+            expect(assertion).to.throw('No server matching \'nonExistentServer/test/responseBody/string\' path defined in OpenAPI spec');
+          });
+
+          it('fails when using .not', function () {
+            const assertion = () => expect(res).to.not.satisfyApiSpec;
+            expect(assertion).to.throw('No server matching \'nonExistentServer/test/responseBody/string\' path defined in OpenAPI spec');
+          });
+        });
+        describe(`res.req.path matches a server ('${serverUrl}') but no endpoint paths`, function () {
+          const res = {
+            status: 200,
+            req: {
+              method: 'GET',
+              path: `${serverUrl}/nonExistentEndpointPath`,
+            },
+            body: 'valid body (string)',
+          };
+
+          it('fails', function () {
+            const assertion = () => expect(res).to.satisfyApiSpec;
+            expect(assertion).to.throw(`No '${serverUrl}/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${util.inspect(expectedMatchingServers)} but no 'serverUrl/endpointPath' combinations)`);
+          });
+
+          it('fails when using .not', function () {
+            const assertion = () => expect(res).to.not.satisfyApiSpec;
+            expect(assertion).to.throw(`No '${serverUrl}/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${util.inspect(expectedMatchingServers)} but no 'serverUrl/endpointPath' combinations)`);
+          });
+        });
+      });
+    }
   });
 });

--- a/test/unit/assertions/definedServerPath.test.js
+++ b/test/unit/assertions/definedServerPath.test.js
@@ -16,7 +16,7 @@
 
 const chai = require('chai');
 const path = require('path');
-const util = require('util');
+const { inspect } = require('util');
 
 const chaiResponseValidator = require('../../..');
 
@@ -83,12 +83,12 @@ describe('Using OpenAPI 3 specs that define servers differently', function () {
 
       it('fails', function () {
         const assertion = () => expect(res).to.satisfyApiSpec;
-        expect(assertion).to.throw(`No '/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${util.inspect(['/'])} but no 'serverUrl/endpointPath' combinations)`);
+        expect(assertion).to.throw(`No '/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${inspect(['/'])} but no 'server/endpointPath' combinations)`);
       });
 
       it('fails when using .not', function () {
         const assertion = () => expect(res).to.not.satisfyApiSpec;
-        expect(assertion).to.throw(`No '/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${util.inspect(['/'])} but no 'serverUrl/endpointPath' combinations)`);
+        expect(assertion).to.throw(`No '/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${inspect(['/'])} but no 'server/endpointPath' combinations)`);
       });
     });
   });
@@ -151,62 +151,94 @@ describe('Using OpenAPI 3 specs that define servers differently', function () {
 
       it('fails', function () {
         const assertion = () => expect(res).to.satisfyApiSpec;
-        expect(assertion).to.throw(`No '/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${util.inspect(['/'])} but no 'serverUrl/endpointPath' combinations)`);
+        expect(assertion).to.throw(`No '/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${inspect(['/'])} but no 'server/endpointPath' combinations)`);
       });
 
       it('fails when using .not', function () {
         const assertion = () => expect(res).to.not.satisfyApiSpec;
-        expect(assertion).to.throw(`No '/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${util.inspect(['/'])} but no 'serverUrl/endpointPath' combinations)`);
+        expect(assertion).to.throw(`No '/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${inspect(['/'])} but no 'server/endpointPath' combinations)`);
       });
     });
   });
 
-  describe('spec\'s server property is an array of servers', function() {
+  describe('spec defines various (relative and absolute) servers', function() {
+    before(function () {
+      const pathToApiSpec = path.join(dirContainingApiSpec, 'variousServers.yml');
+      chai.use(chaiResponseValidator(pathToApiSpec));
+    });
+
+    describe('res.req.path does not match any servers', function () {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: 'nonExistentServer/test/responseBody/string',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('fails', function () {
+        const assertion = () => expect(res).to.satisfyApiSpec;
+        expect(assertion).to.throw('No server matching \'nonExistentServer/test/responseBody/string\' path defined in OpenAPI spec');
+      });
+
+      it('fails when using .not', function () {
+        const assertion = () => expect(res).to.not.satisfyApiSpec;
+        expect(assertion).to.throw('No server matching \'nonExistentServer/test/responseBody/string\' path defined in OpenAPI spec');
+      });
+    });
+
     const tests = {
-      'default server url (\'/\')': {
-        serverUrl: '',
-        expectedMatchingServers: [
-          '/',
-        ],
-      },
-      'relative server url': {
+      'a relative server url': {
         serverUrl: '/relativeServer',
-        expectedMatchingServers: [
-          '/',
-          '/relativeServer',
-        ],
+        expectedMatchingServers: ['/relativeServer'],
       },
-      'different relative server url': {
+      'a different relative server url': {
         serverUrl: '/differentRelativeServer',
-        expectedMatchingServers: [
-          '/',
-          '/differentRelativeServer',
-        ],
+        expectedMatchingServers: ['/differentRelativeServer'],
       },
-      'multiple relative server urls': {
+      'multiple server urls': {
         serverUrl: '/relativeServer2',
-        expectedMatchingServers: [
-          '/',
-          '/relativeServer',
-          '/relativeServer2',
-        ],
+        expectedMatchingServers: ['/relativeServer', '/relativeServer2'],
+      },
+      'base path of absolute server url with http scheme': {
+        serverUrl: '/basePath1',
+        expectedMatchingServers: ['http://api.example.com/basePath1'],
+      },
+      'base path of absolute server url with https scheme': {
+        serverUrl: '/basePath2',
+        expectedMatchingServers: ['https://api.example.com/basePath2'],
+      },
+      'base path of absolute server url with ws scheme': {
+        serverUrl: '/basePath3',
+        expectedMatchingServers: ['ws://api.example.com/basePath3'],
+      },
+      'base path of absolute server url with wss scheme': {
+        serverUrl: '/basePath4',
+        expectedMatchingServers: ['wss://api.example.com/basePath4'],
+      },
+      'base path of absolute server url with port': {
+        serverUrl: '/basePath5',
+        expectedMatchingServers: ['http://api.example.com:8443/basePath5'],
+      },
+      'base path of absolute server url with localhost': {
+        serverUrl: '/basePath6',
+        expectedMatchingServers: ['http://localhost:3025/basePath6'],
+      },
+      'base path of absolute server url with IPv4 host': {
+        serverUrl: '/basePath7',
+        expectedMatchingServers: ['http://10.0.81.36/basePath7'],
       },
     };
 
     for (const [testName, test] of Object.entries(tests)) {
-      describe(`res.req.path contains a ${testName}`, function() {
-
+      describe(`res.req.path matches ${testName}`, function() {
         const {
           serverUrl,
           expectedMatchingServers,
         } = test;
 
-        before(function () {
-          const pathToApiSpec = path.join(dirContainingApiSpec, 'variousServers.yml');
-          chai.use(chaiResponseValidator(pathToApiSpec));
-        });
-
-        describe(`res.req.path matches a server ('${serverUrl}') and an endpoint path`, function () {
+        describe('res.req.path matches a server and an endpoint path', function () {
           const res = {
             status: 200,
             req: {
@@ -225,27 +257,7 @@ describe('Using OpenAPI 3 specs that define servers differently', function () {
             expect(assertion).to.throw('');
           });
         });
-        describe('res.req.path does not match any servers', function () {
-          const res = {
-            status: 200,
-            req: {
-              method: 'GET',
-              path: 'nonExistentServer/test/responseBody/string',
-            },
-            body: 'valid body (string)',
-          };
-
-          it('fails', function () {
-            const assertion = () => expect(res).to.satisfyApiSpec;
-            expect(assertion).to.throw('No server matching \'nonExistentServer/test/responseBody/string\' path defined in OpenAPI spec');
-          });
-
-          it('fails when using .not', function () {
-            const assertion = () => expect(res).to.not.satisfyApiSpec;
-            expect(assertion).to.throw('No server matching \'nonExistentServer/test/responseBody/string\' path defined in OpenAPI spec');
-          });
-        });
-        describe(`res.req.path matches a server ('${serverUrl}') but no endpoint paths`, function () {
+        describe('res.req.path matches a server but no endpoint paths', function () {
           const res = {
             status: 200,
             req: {
@@ -257,15 +269,176 @@ describe('Using OpenAPI 3 specs that define servers differently', function () {
 
           it('fails', function () {
             const assertion = () => expect(res).to.satisfyApiSpec;
-            expect(assertion).to.throw(`No '${serverUrl}/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${util.inspect(expectedMatchingServers)} but no 'serverUrl/endpointPath' combinations)`);
+            expect(assertion).to.throw(`No '${serverUrl}/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${inspect(expectedMatchingServers)} but no 'server/endpointPath' combinations)`);
           });
 
           it('fails when using .not', function () {
             const assertion = () => expect(res).to.not.satisfyApiSpec;
-            expect(assertion).to.throw(`No '${serverUrl}/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${util.inspect(expectedMatchingServers)} but no 'serverUrl/endpointPath' combinations)`);
+            expect(assertion).to.throw(`No '${serverUrl}/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${inspect(expectedMatchingServers)} but no 'server/endpointPath' combinations)`);
           });
         });
       });
     }
+  });
+
+  describe('spec defines only absolute servers with base paths', function() {
+
+    before(function () {
+      const pathToApiSpec = path.join(dirContainingApiSpec, 'onlyAbsoluteServersWithBasePaths.yml');
+      chai.use(chaiResponseValidator(pathToApiSpec));
+    });
+
+    describe('res.req.matches a server base path and an endpoint path', function () {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: '/basePath1/test/responseBody/string',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('passes', function () {
+        expect(res).to.satisfyApiSpec;
+      });
+
+      it('fails when using .not', function () {
+        const assertion = () => expect(res).to.not.satisfyApiSpec;
+        expect(assertion).to.throw('');
+      });
+    });
+
+    describe('res.req.path matches a server base path but no endpoint paths', function () {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: '/basePath1/nonExistentEndpointPath',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('fails', function () {
+        const assertion = () => expect(res).to.satisfyApiSpec;
+        expect(assertion).to.throw(`No '/basePath1/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${inspect(['http://api.example.com/basePath1'])} but no 'server/endpointPath' combinations)`);
+      });
+
+      it('fails when using .not', function () {
+        const assertion = () => expect(res).to.not.satisfyApiSpec;
+        expect(assertion).to.throw(`No '/basePath1/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${inspect(['http://api.example.com/basePath1'])} but no 'server/endpointPath' combinations)`);
+      });
+    });
+
+    describe('res.req.path does not match any defined server base paths, nor the default base path (\'/\')', function () {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: 'nonExistentServer/test/responseBody/string',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('fails', function () {
+        const assertion = () => expect(res).to.satisfyApiSpec;
+        expect(assertion).to.throw('No server matching \'nonExistentServer/test/responseBody/string\' path defined in OpenAPI spec');
+      });
+
+      it('fails when using .not', function () {
+        const assertion = () => expect(res).to.not.satisfyApiSpec;
+        expect(assertion).to.throw('No server matching \'nonExistentServer/test/responseBody/string\' path defined in OpenAPI spec');
+      });
+    });
+
+    describe('res.req.path does not match any defined server base paths, but does match the default base path (\'/\')', function () {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: '/test/responseBody/string',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('fails', function () {
+        const assertion = () => expect(res).to.satisfyApiSpec;
+        expect(assertion).to.throw('No server matching \'/test/responseBody/string\' path defined in OpenAPI spec');
+      });
+
+      it('fails when using .not', function () {
+        const assertion = () => expect(res).to.not.satisfyApiSpec;
+        expect(assertion).to.throw('No server matching \'/test/responseBody/string\' path defined in OpenAPI spec');
+      });
+    });
+  });
+
+  describe('spec defines only absolute servers without base paths', function() {
+
+    before(function () {
+      const pathToApiSpec = path.join(dirContainingApiSpec, 'noServersWithBasePaths.yml');
+      chai.use(chaiResponseValidator(pathToApiSpec));
+    });
+
+    describe('res.req.path matches the default server base path (\'/\') and an endpoint path', function () {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: '/test/responseBody/string',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('passes', function () {
+        expect(res).to.satisfyApiSpec;
+      });
+
+      it('fails when using .not', function () {
+        const assertion = () => expect(res).to.not.satisfyApiSpec;
+        expect(assertion).to.throw('');
+      });
+    });
+
+    describe('res.req.path matches the default server base path (\'/\') but no endpoint paths', function () {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: '/nonExistentEndpointPath',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('fails', function () {
+        const assertion = () => expect(res).to.satisfyApiSpec;
+        expect(assertion).to.throw(`No '/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${inspect(['http://api.example.com'])} but no 'server/endpointPath' combinations)`);
+      });
+
+      it('fails when using .not', function () {
+        const assertion = () => expect(res).to.not.satisfyApiSpec;
+        expect(assertion).to.throw(`No '/nonExistentEndpointPath' path defined in OpenAPI spec. (Matches servers ${inspect(['http://api.example.com'])} but no 'server/endpointPath' combinations)`);
+      });
+    });
+
+    describe('res.req.path does not match the default server base path (\'/\') nor any servers', function () {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: 'nonExistentServer/test/responseBody/string',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('fails', function () {
+        const assertion = () => expect(res).to.satisfyApiSpec;
+        expect(assertion).to.throw('No server matching \'nonExistentServer/test/responseBody/string\' path defined in OpenAPI spec');
+      });
+
+      it('fails when using .not', function () {
+        const assertion = () => expect(res).to.not.satisfyApiSpec;
+        expect(assertion).to.throw('No server matching \'nonExistentServer/test/responseBody/string\' path defined in OpenAPI spec');
+      });
+    });
   });
 });

--- a/test/unit/assertions/differentRequestModules.test.js
+++ b/test/unit/assertions/differentRequestModules.test.js
@@ -31,11 +31,14 @@ const { port } = require('../../config');
 const appOrigin = `http://localhost:${port}`;
 const appPathToTest = '/local/test/responseBody/string';
 const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/valid/openapi3.yml');
-chai.use(chaiResponseValidator(pathToApiSpec));
 chai.use(chaiAsPromised);
 const { expect } = chai;
 
 describe('Parsing responses from different request modules', function () {
+
+  before(function() {
+    chai.use(chaiResponseValidator(pathToApiSpec));
+  });
 
   describe('modules that differentiate between res.body and res.text', function() {
 

--- a/test/unit/assertions/satisfyApiSpec.test.js
+++ b/test/unit/assertions/satisfyApiSpec.test.js
@@ -36,7 +36,7 @@ for (const spec of openApiSpecs) {
   const { openApiVersion, pathToApiSpec } = spec;
 
   // add a path to a server if testing in openAPI 3
-  const serverPath = openApiVersion == 3 ? '/local' : '';
+  const serverUrl = openApiVersion == 3 ? '/local' : '';
 
   describe(`expect(res).to.satisfyApiSpec (using an OpenAPI ${openApiVersion} spec)`, function () {
     before(function () {
@@ -50,7 +50,7 @@ for (const spec of openApiSpecs) {
               status: 200,
               req: {
                 method: 'GET',
-                path: `${serverPath}/test/responseBody/string`,
+                path: `${serverUrl}/test/responseBody/string`,
               },
               body: 'valid body (string)',
             };
@@ -77,7 +77,7 @@ for (const spec of openApiSpecs) {
               status: 200,
               req: {
                 method: 'GET',
-                path: `${serverPath}/test/responseBody/referencesSchemaObject`,
+                path: `${serverUrl}/test/responseBody/referencesSchemaObject`,
               },
               body: 'valid body (string)',
             };
@@ -97,7 +97,7 @@ for (const spec of openApiSpecs) {
               status: 204,
               req: {
                 method: 'GET',
-                path: `${serverPath}/test/responseBody/empty`,
+                path: `${serverUrl}/test/responseBody/empty`,
               },
             };
 
@@ -117,7 +117,7 @@ for (const spec of openApiSpecs) {
             status: 200,
             req: {
               method: 'GET',
-              path: `${serverPath}/test/responseReferencesResponseDefinitionObject`,
+              path: `${serverUrl}/test/responseReferencesResponseDefinitionObject`,
             },
             body: 'valid body (string)',
           };
@@ -145,7 +145,7 @@ for (const spec of openApiSpecs) {
               status: 201,
               req: {
                 method: 'GET',
-                path: `${serverPath}/test/multipleResponsesDefined`,
+                path: `${serverUrl}/test/multipleResponsesDefined`,
               },
               body: 'valid body (string)',
             };
@@ -165,7 +165,7 @@ for (const spec of openApiSpecs) {
               status: 202,
               req: {
                 method: 'GET',
-                path: `${serverPath}/test/multipleResponsesDefined`,
+                path: `${serverUrl}/test/multipleResponsesDefined`,
               },
               body: 123456, // valid body (integer)
             };
@@ -185,7 +185,7 @@ for (const spec of openApiSpecs) {
               status: 203,
               req: {
                 method: 'GET',
-                path: `${serverPath}/test/multipleResponsesDefined`,
+                path: `${serverUrl}/test/multipleResponsesDefined`,
               },
               // no body
             };
@@ -207,7 +207,7 @@ for (const spec of openApiSpecs) {
               status: 204,
               req: {
                 method: 'GET',
-                path: `${serverPath}/test/queryParams?exampleQueryParam=foo`,
+                path: `${serverUrl}/test/queryParams?exampleQueryParam=foo`,
               },
             };
 
@@ -226,7 +226,7 @@ for (const spec of openApiSpecs) {
               status: 204,
               req: {
                 method: 'GET',
-                path: `${serverPath}/test/queryParams?${'exampleQueryParam=foo'}&${'exampleQueryParam2=bar'}`,
+                path: `${serverUrl}/test/queryParams?${'exampleQueryParam=foo'}&${'exampleQueryParam2=bar'}`,
               },
             };
 
@@ -245,7 +245,7 @@ for (const spec of openApiSpecs) {
               status: 204,
               req: {
                 method: 'GET',
-                path: `${serverPath}/test/pathParams/foo`,
+                path: `${serverUrl}/test/pathParams/foo`,
               },
             };
 
@@ -264,7 +264,7 @@ for (const spec of openApiSpecs) {
               status: 204,
               req: {
                 method: 'GET',
-                path: `${serverPath}/test/multiplePathParams/foo/bar`,
+                path: `${serverUrl}/test/multiplePathParams/foo/bar`,
               },
             };
 
@@ -283,7 +283,7 @@ for (const spec of openApiSpecs) {
               status: 204,
               req: {
                 method: 'GET',
-                path: `${serverPath}/test/pathAndQueryParams/${'foo'}?${'exampleQueryParam=bar'}`,
+                path: `${serverUrl}/test/pathAndQueryParams/${'foo'}?${'exampleQueryParam=bar'}`,
               },
             };
 
@@ -304,7 +304,7 @@ for (const spec of openApiSpecs) {
             status: 418,
             req: {
               method: 'GET',
-              path: `${serverPath}/test/responseStatus`,
+              path: `${serverUrl}/test/responseStatus`,
             },
           };
 
@@ -324,7 +324,7 @@ for (const spec of openApiSpecs) {
             status: 204,
             req: {
               method: 'GET',
-              path: `${serverPath}/test/responseBody/empty`,
+              path: `${serverUrl}/test/responseBody/empty`,
             },
             body: [{ nestedProperty: 'invalid body (should be empty)' }],
           };
@@ -367,18 +367,18 @@ for (const spec of openApiSpecs) {
           status: 204,
           req: {
             method: 'GET',
-            path: `${serverPath}/does/not/exist`,
+            path: `${serverUrl}/does/not/exist`,
           },
         };
 
         it('fails', function () {
           const assertion = () => expect(res).to.satisfyApiSpec;
-          expect(assertion).to.throw('No \'/does/not/exist\' path defined in OpenAPI spec');
+          expect(assertion).to.throw(`No '${serverUrl}/does/not/exist' path defined in OpenAPI spec`);
         });
 
         it('fails when using .not', function () {
           const assertion = () => expect(res).to.not.satisfyApiSpec;
-          expect(assertion).to.throw('No \'/does/not/exist\' path defined in OpenAPI spec');
+          expect(assertion).to.throw(`No '${serverUrl}/does/not/exist' path defined in OpenAPI spec`);
         });
       });
 
@@ -387,7 +387,7 @@ for (const spec of openApiSpecs) {
           status: 204,
           req: {
             method: 'HEAD',
-            path: `${serverPath}/test/HTTPMethod`,
+            path: `${serverUrl}/test/HTTPMethod`,
           },
         };
 


### PR DESCRIPTION
For https://github.com/RuntimeTools/chai-openapi-response-validator/issues/30. (Also extends https://github.com/RuntimeTools/chai-openapi-response-validator/issues/17).

Should support the 'Server URL Format' and 'Relative URLs' sections of https://swagger.io/docs/specification/api-host-and-base-path/. We do not yet support 'Server Templating' or 'Overriding Servers'

Should satisfy [description of 'servers' field in OpenAPI 3 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#fixed-fields)