### PR TITLE
feat: support string responses with text/html header

### DIFF
--- a/lib/classes/BaseOpenApiSpec.js
+++ b/lib/classes/BaseOpenApiSpec.js
@@ -74,7 +74,10 @@ class OpenApiSpec {
     });
 
     const [expectedResStatus] = Object.keys(expectedResponse);
-    const validationError = resValidator.validateResponse(expectedResStatus, actualResponse.body());
+    const validationError = resValidator.validateResponse(
+      expectedResStatus,
+      actualResponse.getBodyForValidation(),
+    );
     return validationError;
   }
 }

--- a/lib/classes/Response.js
+++ b/lib/classes/Response.js
@@ -5,17 +5,20 @@ const utils = require('../utils');
 class Response {
   constructor(res) {
     this.res = res;
+    this.isResTextPopulatedInsteadOfResBody = (utils.isEmptyObj(this.body()))
+      && this.res.hasOwnProperty('text')
+      && this.res.text !== '{}';
   }
 
   status() {
-    return this.res.status // all modules except request-promise
-      || this.res.statusCode // request-promise
+    return this.res.status // for all modules except request-promise
+      || this.res.statusCode // for request-promise
     ;
   }
 
   body() {
-    let body = this.res.body // all modules except axios
-      || this.res.data // axios
+    let body = this.res.body // for all modules except axios
+      || this.res.data // for axios
       ;
     if (typeof body == 'string') {
       body = body.replace(/"/g, '');
@@ -23,9 +26,31 @@ class Response {
     return body;
   }
 
+  getBodyForValidation() {
+    // for superagent-based request modules
+    if (this.isResTextPopulatedInsteadOfResBody) {
+      return this.res.text;
+    }
+
+    const body = this.body();
+
+    // for request-promise
+    try {
+      const parsedBody = JSON.parse(body);
+      if (utils.isEmptyObj(parsedBody)) {
+        return parsedBody;
+      }
+    } catch (error) {
+      // if JSON.parse errors, then body is JSON not string,
+      // so just move to the next block and return the body
+    }
+
+    return body;
+  }
+
   req() {
-    return this.res.req // all modules except axios
-      || this.res.request; // axios
+    return this.res.req // for all modules except axios
+      || this.res.request; // for axios
   }
 
   summary() {
@@ -33,9 +58,12 @@ class Response {
       status: this.status(),
       body: this.body(),
     };
-    if (utils.isEmptyObj(this.body()) && this.res.hasOwnProperty('text')) {
+
+    // for superagent-based request modules
+    if (this.isResTextPopulatedInsteadOfResBody) {
       summary.text = this.res.text;
     }
+
     return summary;
   }
 

--- a/test/resources/exampleApp.js
+++ b/test/resources/exampleApp.js
@@ -3,11 +3,16 @@ const { port } = require('../config');
 
 const app = express();
 
-app.get('/local/test/responseBody/string', (req, res) =>
+app.get('/local/test/header/application/json/and/responseBody/string', (req, res) =>
   res.json('res.body is a string')
 );
-app.get('/local/test/responseBody/emptyObject', (req, res) =>
-  res.send('res.body is an empty object; res.text is a string')
+
+app.get('/local/test/header/application/json/and/responseBody/emptyObject', (req, res) =>
+  res.send({})
+);
+
+app.get('/local/test/header/text/html', (req, res) =>
+  res.send('res.body is a string')
 );
 
 app.listen(

--- a/test/resources/exampleOpenApiFiles/valid/openapi3.yml
+++ b/test/resources/exampleOpenApiFiles/valid/openapi3.yml
@@ -32,15 +32,6 @@ paths:
       responses:
         204:
           description: No response body
-  /test/responseBody/emptyObject:
-    get:
-      responses:
-        200:
-          description: Response body is an empty object. (Used to test that res.text is populated instead)
-          content:
-            application/json:
-              schema:
-                type: object
   /test/responseReferencesResponseDefinitionObject:
     get:
       responses:
@@ -116,6 +107,33 @@ paths:
       responses:
         204:
           description: No response body
+  /test/header/application/json/and/responseBody/string:
+    get:
+      responses:
+        200:
+          description: Response header is application/json, and response body is a string
+          content:
+            application/json:
+              schema:
+                type: string
+  /test/header/application/json/and/responseBody/emptyObject:
+    get:
+      responses:
+        200:
+          description: Response header is application/json, and response body is an empty object. (Used to test that res.text is populated)
+          content:
+            application/json:
+              schema:
+                type: object
+  /test/header/text/html:
+    get:
+      responses:
+        200:
+          description: Response header is text/html, and response body or text is a string
+          content:
+            text/html:
+              schema:
+                type: string
 components:
   schemas:
     ExampleSchemaObject:

--- a/test/unit/assertions/differentRequestModules.test.js
+++ b/test/unit/assertions/differentRequestModules.test.js
@@ -29,7 +29,6 @@ const app = require('../../resources/exampleApp');
 const { port } = require('../../config');
 
 const appOrigin = `http://localhost:${port}`;
-const appPathToTest = '/local/test/responseBody/string';
 const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/valid/openapi3.yml');
 chai.use(chaiAsPromised);
 const { expect } = chai;
@@ -40,104 +39,18 @@ describe('Parsing responses from different request modules', function () {
     chai.use(chaiResponseValidator(pathToApiSpec));
   });
 
-  describe('modules that differentiate between res.body and res.text', function() {
+  describe('chai-http', function() {
+    chai.use(chaiHttp);
 
-    describe('chai-http', function() {
-      chai.use(chaiHttp);
-
-      describe('res.body is a string', function() {
-        const res = chai.request(app).get(appPathToTest);
-        it('passes', async function() {
-          expect(await res).to.satisfyApiSpec;
-        });
-        it('fails when using .not', function () {
-          const assertion = async() => expect(await res).to.not.satisfyApiSpec;
-          return expect(assertion()).to.be.rejectedWith(
-            `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/responseBody/string' in OpenAPI spec\nres: ${
-              util.inspect({
-                status: 200,
-                body: 'res.body is a string',
-              })
-            }`
-          );
-        });
-      });
-
-      describe('res.body is an empty object', function() {
-        const res = chai.request(app).get('/local/test/responseBody/emptyObject');
-        it('passes', async function() {
-          expect(await res).to.satisfyApiSpec;
-        });
-        it('fails when using .not', function () {
-          const assertion = async() => expect(await res).to.not.satisfyApiSpec;
-          return expect(assertion()).to.be.rejectedWith(
-            `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/responseBody/emptyObject' in OpenAPI spec\nres: ${
-              util.inspect({
-                status: 200,
-                body: {},
-                text: 'res.body is an empty object; res.text is a string',
-              })
-            }`
-          );
-        });
-      });
-
-    });
-
-    describe('supertest', function() {
-
-      describe('res.body is a string', function() {
-        const res = supertest(app).get(appPathToTest);
-        it('passes', async function() {
-          expect(await res).to.satisfyApiSpec;
-        });
-        it('fails when using .not', function () {
-          const assertion = async() => expect(await res).to.not.satisfyApiSpec;
-          return expect(assertion()).to.be.rejectedWith(
-            `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/responseBody/string' in OpenAPI spec\nres: ${
-              util.inspect({
-                status: 200,
-                body: 'res.body is a string',
-              })
-            }`
-          );
-        });
-      });
-
-      describe('res.body is an empty object', function() {
-        const res = supertest(app).get('/local/test/responseBody/emptyObject');
-        it('passes', async function() {
-          expect(await res).to.satisfyApiSpec;
-        });
-        it('fails when using .not', function () {
-          const assertion = async() => expect(await res).to.not.satisfyApiSpec;
-          return expect(assertion()).to.be.rejectedWith(
-            `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/responseBody/emptyObject' in OpenAPI spec\nres: ${
-              util.inspect({
-                status: 200,
-                body: {},
-                text: 'res.body is an empty object; res.text is a string',
-              })
-            }`
-          );
-        });
-      });
-
-    });
-
-  });
-
-  describe('modules that don\'t differentiate between res.body and res.text', function() {
-
-    describe('axios', function() {
-      const res = axios.get(`${appOrigin}${appPathToTest}`);
+    describe('res header is application/json, and res.body is a string', function() {
+      const res = chai.request(app).get('/local/test/header/application/json/and/responseBody/string');
       it('passes', async function() {
         expect(await res).to.satisfyApiSpec;
       });
       it('fails when using .not', function () {
         const assertion = async() => expect(await res).to.not.satisfyApiSpec;
         return expect(assertion()).to.be.rejectedWith(
-          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/responseBody/string' in OpenAPI spec\nres: ${
+          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/header/application/json/and/responseBody/string' in OpenAPI spec\nres: ${
             util.inspect({
               status: 200,
               body: 'res.body is a string',
@@ -147,10 +60,187 @@ describe('Parsing responses from different request modules', function () {
       });
     });
 
-    describe('request-promise', function() {
+    describe('res header is application/json, and res.body is {}', function() {
+      const res = chai.request(app).get('/local/test/header/application/json/and/responseBody/emptyObject');
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/header/application/json/and/responseBody/emptyObject' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 200,
+              body: {},
+            })
+          }`
+        );
+      });
+    });
+
+    describe('res header is text/html, res.body is {}, and res.text is a string', function() {
+      const res = chai.request(app).get('/local/test/header/text/html');
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/header/text/html' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 200,
+              body: {},
+              text: 'res.body is a string',
+            })
+          }`
+        );
+      });
+    });
+
+  });
+
+  describe('supertest', function() {
+
+    describe('res header is application/json, and res.body is a string', function() {
+      const res = supertest(app).get('/local/test/header/application/json/and/responseBody/string');
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/header/application/json/and/responseBody/string' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 200,
+              body: 'res.body is a string',
+            })
+          }`
+        );
+      });
+    });
+
+    describe('res header is application/json, and res.body is {}', function() {
+      const res = supertest(app).get('/local/test/header/application/json/and/responseBody/emptyObject');
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/header/application/json/and/responseBody/emptyObject' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 200,
+              body: {},
+            })
+          }`
+        );
+      });
+    });
+
+    describe('res header is text/html, res.body is {}, and res.text is a string', function() {
+      const res = supertest(app).get('/local/test/header/text/html');
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/header/text/html' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 200,
+              body: {},
+              text: 'res.body is a string',
+            })
+          }`
+        );
+      });
+    });
+
+  });
+
+  describe('axios', function() {
+
+    describe('res header is application/json, and res.body is a string', function() {
+      const res = axios.get(`${appOrigin}/local/test/header/application/json/and/responseBody/string`);
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/header/application/json/and/responseBody/string' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 200,
+              body: 'res.body is a string',
+            })
+          }`
+        );
+      });
+    });
+
+    describe('res header is application/json, and res.body is {}', function() {
+      const res = axios.get(`${appOrigin}/local/test/header/application/json/and/responseBody/emptyObject`);
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/header/application/json/and/responseBody/emptyObject' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 200,
+              body: {},
+            })
+          }`
+        );
+      });
+    });
+
+    describe('res header is text/html, res.body is a string', function() {
+      const res = axios.get(`${appOrigin}/local/test/header/text/html`);
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/header/text/html' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 200,
+              body: 'res.body is a string',
+            })
+          }`
+        );
+      });
+    });
+
+  });
+
+  describe('request-promise', function() {
+    const res = requestPromise({
+      method: 'GET',
+      uri: `${appOrigin}/local/test/header/application/json/and/responseBody/string`,
+      resolveWithFullResponse: true,
+    });
+    it('passes', async function() {
+      expect(await res).to.satisfyApiSpec;
+    });
+    it('fails when using .not', function () {
+      const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+      return expect(assertion()).to.be.rejectedWith(
+        `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/header/application/json/and/responseBody/string' in OpenAPI spec\nres: ${
+          util.inspect({
+            status: 200,
+            body: 'res.body is a string',
+          })
+        }`
+      );
+    });
+
+    describe('res header is application/json, and res.body is a string', function() {
       const res = requestPromise({
         method: 'GET',
-        uri: `${appOrigin}${appPathToTest}`,
+        uri: `${appOrigin}/local/test/header/application/json/and/responseBody/string`,
         resolveWithFullResponse: true,
       });
       it('passes', async function() {
@@ -159,7 +249,51 @@ describe('Parsing responses from different request modules', function () {
       it('fails when using .not', function () {
         const assertion = async() => expect(await res).to.not.satisfyApiSpec;
         return expect(assertion()).to.be.rejectedWith(
-          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/responseBody/string' in OpenAPI spec\nres: ${
+          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/header/application/json/and/responseBody/string' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 200,
+              body: 'res.body is a string',
+            })
+          }`
+        );
+      });
+    });
+
+    describe('res header is application/json, and res.body is \'{}\'', function() {
+      const res = requestPromise({
+        method: 'GET',
+        uri: `${appOrigin}/local/test/header/application/json/and/responseBody/emptyObject`,
+        resolveWithFullResponse: true,
+      });
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/header/application/json/and/responseBody/emptyObject' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 200,
+              body: '{}',
+            })
+          }`
+        );
+      });
+    });
+
+    describe('res header is text/html, res.body is a string', function() {
+      const res = requestPromise({
+        method: 'GET',
+        uri: `${appOrigin}/local/test/header/text/html`,
+        resolveWithFullResponse: true,
+      });
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/header/text/html' in OpenAPI spec\nres: ${
             util.inspect({
               status: 200,
               body: 'res.body is a string',


### PR DESCRIPTION
for https://github.com/RuntimeTools/chai-openapi-response-validator/issues/29.

* resolves the case described in https://github.com/RuntimeTools/chai-openapi-response-validator/issues/29#issuecomment-567064245, which affected superagent-based request packages and request-promise
* improves testing around our 4 supported request packages