### PR TITLE
Release 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-openapi-response-validator",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Simple Chai support for asserting that HTTP responses satisfy an OpenAPI spec",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Resolves #29 

Fixes:
* User of superagent-based request packages (e.g. supertest, chai-http) can validate responses with text/html headers https://github.com/RuntimeTools/chai-openapi-response-validator/pull/35