### PR TITLE
User can define api spec directly as object

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ paths:
     get:
       responses:
         200:
-          description: Response body should be an object with fields 'stringProperty' and 'integer property'
+          description: Response body should be an object with fields 'stringProperty' and 'integerProperty'
           content:
             application/json:
               schema:

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Simple Chai support for asserting that HTTP responses satisfy an OpenAPI spec.
 
 If your server's behaviour doesn't match your API documentation, then you need to correct your server, your documentation, or both. The sooner you know the better.
 
-This plugin allows you to automatically test whether your server's behaviour and documentation match. It extends the [Chai Assertion Library](https://www.chaijs.com/) to support the [OpenAPI standard](https://swagger.io/docs/specification/about/) for documenting REST APIs.
+This plugin lets you automatically test whether your server's behaviour and documentation match. It extends the [Chai Assertion Library](https://www.chaijs.com/) to support the [OpenAPI standard](https://swagger.io/docs/specification/about/) for documenting REST APIs.
 
 ## Features
 - Validates the status and body of HTTP responses against an OpenAPI spec
-- Easily load your OpenAPI spec just once in your tests
+- Load your OpenAPI spec just once in your tests (load from a [filepath](#load-openapi-spec-from-a-filepath) or [object](#load-openapi-spec-from-an-object))
 - Supports OpenAPI [2](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md) and [3](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md)
 - Supports OpenAPI specs in YAML and JSON formats
 - Supports `$ref` in response definitions (i.e. `$ref: '#/definitions/ComponentType/ComponentName'`)
@@ -45,11 +45,11 @@ const chaiResponseValidator = require('chai-openapi-response-validator');
 chai.use(chaiResponseValidator('path/to/openapi.yml'));
 
 // Write your test (e.g. using Mocha)
-describe('GET /example/request', function() {
+describe('GET /example/endpoint', function() {
   it('should satisfy OpenAPI spec', async function() {
 
     // Get an HTTP response from your server (e.g. using axios)
-    const res = await axios.get('http://localhost:3000/example/request');
+    const res = await axios.get('http://localhost:3000/example/endpoint');
 
     expect(res.status).to.equal(200);
 
@@ -59,7 +59,7 @@ describe('GET /example/request', function() {
 });
 ```
 
-### 2. Write an OpenAPI Spec (and save at `path/to/openapi.yml`):
+### 2. Write an OpenAPI Spec (and save to `path/to/openapi.yml`):
 ```yaml
 openapi: 3.0.0
 info:
@@ -70,7 +70,7 @@ paths:
     get:
       responses:
         200:
-          description: Response body should be a string
+          description: Response body should be an object with fields 'stringProperty' and 'integer property'
           content:
             application/json:
               schema:
@@ -115,7 +115,7 @@ paths:
 };
 ```
 
-Output from test failure:
+##### Output from test failure:
 
 ```javascript
 AssertionError: expected res to satisfy API spec:
@@ -138,6 +138,92 @@ AssertionError: expected res to satisfy API spec:
 }
 ```
 
+### Alternative step 1: load your OpenAPI spec from an object (instead of a filepath):
+```javascript
+// Set up Chai
+const chai = require('chai');
+const expect = chai.expect;
+
+// Import this plugin
+const chaiResponseValidator = require('chai-openapi-response-validator');
+
+// Get an object representing your OpenAPI spec
+const openApiSpec = {
+  openapi: '3.0.0',
+  info: {
+    title: 'Example API',
+    version: '0.1.0',
+  },
+  paths: {
+    '/example/endpoint': {
+      get: {
+        responses: {
+          '200': {
+            description: 'Response body should be a string',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+// Load that OpenAPI object into this plugin
+chai.use(chaiResponseValidator(openApiSpec));
+
+// Write your test (e.g. using Mocha)
+describe('GET /example/endpoint', function() {
+  it('should satisfy OpenAPI spec', async function() {
+
+    // Get an HTTP response from your server (e.g. using axios)
+    const res = await axios.get('http://localhost:3000/example/endpoint');
+
+    expect(res.status).to.equal(200);
+
+    // Assert that the HTTP response satisfies the OpenAPI spec
+    expect(res).to.satisfyApiSpec;
+  });
+});
+```
+
+#### This lets you load your OpenAPI spec from a web endpoint:
+```javascript
+// Set up Chai
+const chai = require('chai');
+const expect = chai.expect;
+
+// Import this plugin
+const chaiResponseValidator = require('chai-openapi-response-validator');
+
+// Write your test (e.g. using Mocha)
+describe('GET /example/endpoint', function() {
+
+  // Load your OpenAPI spec from a web endpoint
+  before(async function() {
+    const axios = require('axios');
+    const response = await axios.get('url/to/openapi/spec');
+    const openApiSpec = response.data; // e.g. { openapi: '3.0.0', <etc> };
+    chai.use(chaiResponseValidator(openApiSpec));
+  });
+
+  it('should satisfy OpenAPI spec', async function() {
+
+    // Get an HTTP response from your server (e.g. using axios)
+    const res = await axios.get('http://localhost:3000/example/endpoint');
+
+    expect(res.status).to.equal(200);
+
+    // Assert that the HTTP response satisfies the OpenAPI spec
+    expect(res).to.satisfyApiSpec;
+  });
+});
+```
 
 ## Contributing
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,8 +18,8 @@ const utils = require('./utils');
 const Response = require('./classes/Response');
 const openApiSpecFactory = require('./openApiSpecFactory');
 
-module.exports = function (pathToOpenApiSpec) {
-  const openApiSpec = openApiSpecFactory.makeApiSpec(pathToOpenApiSpec);
+module.exports = function (filepathOrObject) {
+  const openApiSpec = openApiSpecFactory.makeApiSpec(filepathOrObject);
 
   return function (chai) {
     const { Assertion } = chai;

--- a/lib/openApiSpecFactory.js
+++ b/lib/openApiSpecFactory.js
@@ -2,13 +2,14 @@ const fs = require('fs-extra');
 const yaml = require('js-yaml');
 const path = require('path');
 const OpenAPISchemaValidator = require('openapi-schema-validator').default;
+const typeOf = require('typeof');
 
 const utils = require('./utils');
 const OpenApi2Spec = require('./classes/OpenApi2Spec');
 const OpenApi3Spec = require('./classes/OpenApi3Spec');
 
-function makeApiSpec(filepath) {
-  const spec = loadFile(filepath);
+function makeApiSpec(filepathOrObject) {
+  const spec = loadSpec(filepathOrObject);
   validateSpec(spec);
   if (getOpenApiVersion(spec) === '2.0') {
     return new OpenApi2Spec(spec);
@@ -17,15 +18,30 @@ function makeApiSpec(filepath) {
   return new OpenApi3Spec(spec);
 }
 
+function loadSpec(arg) {
+  const argType = typeOf(arg);
+  try {
+    if (argType === 'string') {
+      return loadFile(arg);
+    } else if (argType === 'object') {
+      return arg;
+    } else {
+      throw new Error(`Received type '${argType}'`);
+    }
+  } catch (error) {
+    throw new Error(`The provided argument must be either an absolute filepath or an object representing an OpenAPI specification.\nError details: ${error.message}`);
+  }
+}
+
 function loadFile(filepath) {
   if (!path.isAbsolute(filepath)) {
-    throw new Error('The "path" argument must be an absolute filepath');
+    throw new Error(`'${filepath}' is not an absolute filepath`);
   }
   const fileData = fs.readFileSync(filepath);
   try {
     return yaml.safeLoad(fileData);
   } catch (error) {
-    throw new Error(`Unable to read the specified OpenAPI document. File is invalid YAML or JSON:\n${error.message}`);
+    throw new Error(`Invalid YAML or JSON:\n${error.message}`);
   }
 }
 
@@ -37,7 +53,7 @@ function validateSpec(spec) {
       throw new Error(utils.stringify(errors));
     }
   } catch (error) {
-    throw new Error(`File is not a valid OpenAPI spec.\nError(s): ${error.message}`);
+    throw new Error(`Invalid OpenAPI spec: ${error.message}`);
   }
 
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-openapi-response-validator",
-  "version": "0.4.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4990,6 +4990,11 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typeof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typeof/-/typeof-1.0.0.tgz",
+      "integrity": "sha1-nIRAPyMjrlOZFnJ1SXY46h0vJEA="
     },
     "underscore": {
       "version": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "js-yaml": "^3.13.1",
     "openapi-response-validator": "^3.8.1",
     "openapi-schema-validator": "^3.0.3",
-    "path-parser": "^4.2.0"
+    "path-parser": "^4.2.0",
+    "typeof": "^1.0.0"
   },
   "husky": {
     "hooks": {

--- a/test/unit/setup.test.js
+++ b/test/unit/setup.test.js
@@ -21,84 +21,85 @@ const chaiResponseValidator = require('../..');
 const { expect } = chai;
 
 describe('chaiResponseValidator(pathToApiSpec)', function () {
-  describe('with valid \'pathToApiSpec\' (absolute path to a .yml or .json file)', function () {
-    describe('valid OpenAPI file', function () {
-      describe('YAML', function () {
-        it('returns a function', function () {
-          const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/valid/openapi3.yml');
-          expect(chaiResponseValidator(pathToApiSpec)).to.be.a('function');
-        });
-      });
-      describe('JSON', function () {
-        it('returns a function', function () {
-          const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/valid/openapi3.json');
-          expect(chaiResponseValidator(pathToApiSpec)).to.be.a('function');
-        });
+
+  describe('neither string nor object', function () {
+    it('throws a relevant error', function () {
+      const func = () => chaiResponseValidator(123);
+      expect(func).to.throw('The "path" argument must be of type string. Received type number');
+    });
+  });
+
+  describe('non-absolute path', function () {
+    it('throws a relevant error', function () {
+      const func = () => chaiResponseValidator('./');
+      expect(func).to.throw('The "path" argument must be an absolute filepath');
+    });
+  });
+
+  describe('absolute path to a non-existent file', function () {
+    it('throws a relevant error', function () {
+      const func = () => chaiResponseValidator('/non-existent-file.yml');
+      expect(func).to.throw('no such file or directory, open \'/non-existent-file.yml\'');
+    });
+  });
+
+  describe('absolute path to a file that is neither YAML nor JSON', function () {
+    it('throws a relevant error', function () {
+      const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/invalid/fileFormat/neitherYamlNorJson.js');
+      const func = () => chaiResponseValidator(pathToApiSpec);
+      expect(func).to.throw('Unable to read the specified OpenAPI document. File is invalid YAML or JSON');
+    });
+  });
+
+  describe('absolute path to an invalid OpenAPI file', function () {
+    describe('YAML file that is empty', function () {
+      it('throws a relevant error', function () {
+        const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/invalid/fileFormat/emptyYaml.yml');
+        const func = () => chaiResponseValidator(pathToApiSpec);
+        expect(func).to.throw('File is not a valid OpenAPI spec.');
       });
     });
-
-    describe('invalid OpenAPI file', function () {
-      describe('YAML file that is empty', function () {
-        it('throws a relevant error', function () {
-          const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/invalid/fileFormat/emptyYaml.yml');
-          const func = () => chaiResponseValidator(pathToApiSpec);
-          expect(func).to.throw('File is not a valid OpenAPI spec.');
-        });
+    describe('YAML file that is invalid YAML', function () {
+      it('throws a relevant error', function () {
+        const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/invalid/fileFormat/invalidYamlFormat.yml');
+        const func = () => chaiResponseValidator(pathToApiSpec);
+        expect(func).to.throw('Unable to read the specified OpenAPI document. File is invalid YAML or JSON');
       });
-      describe('YAML file that is invalid YAML', function () {
-        it('throws a relevant error', function () {
-          const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/invalid/fileFormat/invalidYamlFormat.yml');
-          const func = () => chaiResponseValidator(pathToApiSpec);
-          expect(func).to.throw('Unable to read the specified OpenAPI document. File is invalid YAML or JSON');
-        });
+    });
+    describe('JSON file that is invalid JSON', function () {
+      it('throws a relevant error', function () {
+        const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/invalid/fileFormat/invalidJsonFormat.json');
+        const func = () => chaiResponseValidator(pathToApiSpec);
+        expect(func).to.throw('Unable to read the specified OpenAPI document. File is invalid YAML or JSON');
       });
-      describe('JSON file that is invalid JSON', function () {
-        it('throws a relevant error', function () {
-          const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/invalid/fileFormat/invalidJsonFormat.json');
-          const func = () => chaiResponseValidator(pathToApiSpec);
-          expect(func).to.throw('Unable to read the specified OpenAPI document. File is invalid YAML or JSON');
-        });
+    });
+    describe('YAML file that is invalid OpenAPI 3', function () {
+      it('throws a relevant error', function () {
+        const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/invalid/openApi/openApi3.yml');
+        const func = () => chaiResponseValidator(pathToApiSpec);
+        expect(func).to.throw('File is not a valid OpenAPI spec');
       });
-      describe('invalid OpenAPI 3', function () {
-        it('throws a relevant error', function () {
-          const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/invalid/openApi/openApi3.yml');
-          const func = () => chaiResponseValidator(pathToApiSpec);
-          expect(func).to.throw('File is not a valid OpenAPI spec');
-        });
-      });
-      describe('invalid OpenAPI 2', function () {
-        it('throws a relevant error', function () {
-          const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/invalid/openApi/openApi2.json');
-          const func = () => chaiResponseValidator(pathToApiSpec);
-          expect(func).to.throw('File is not a valid OpenAPI spec');
-        });
+    });
+    describe('JSON file that is invalid OpenAPI 2', function () {
+      it('throws a relevant error', function () {
+        const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/invalid/openApi/openApi2.json');
+        const func = () => chaiResponseValidator(pathToApiSpec);
+        expect(func).to.throw('File is not a valid OpenAPI spec');
       });
     });
   });
-  describe('with invalid \'pathToApiSpec\'', function () {
-    describe('non-string', function () {
-      it('throws a relevant error', function () {
-        const func = () => chaiResponseValidator(123);
-        expect(func).to.throw('The "path" argument must be of type string. Received type number');
+
+  describe('absolute path to a valid OpenAPI file', function () {
+    describe('YAML', function () {
+      it('returns a function', function () {
+        const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/valid/openapi3.yml');
+        expect(chaiResponseValidator(pathToApiSpec)).to.be.a('function');
       });
     });
-    describe('non-absolute path', function () {
-      it('throws a relevant error', function () {
-        const func = () => chaiResponseValidator('./');
-        expect(func).to.throw('The "path" argument must be an absolute filepath');
-      });
-    });
-    describe('absolute path to a non-existent file', function () {
-      it('throws a relevant error', function () {
-        const func = () => chaiResponseValidator('/non-existent-file.yml');
-        expect(func).to.throw('no such file or directory, open \'/non-existent-file.yml\'');
-      });
-    });
-    describe('absolute path to a file that is neither YAML nor JSON', function () {
-      it('throws a relevant error', function () {
-        const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/invalid/fileFormat/neitherYamlNorJson.js');
-        const func = () => chaiResponseValidator(pathToApiSpec);
-        expect(func).to.throw('Unable to read the specified OpenAPI document. File is invalid YAML or JSON');
+    describe('JSON', function () {
+      it('returns a function', function () {
+        const pathToApiSpec = path.resolve('test/resources/exampleOpenApiFiles/valid/openapi3.json');
+        expect(chaiResponseValidator(pathToApiSpec)).to.be.a('function');
       });
     });
   });


### PR DESCRIPTION
Part of https://github.com/RuntimeTools/chai-openapi-response-validator/issues/31: allows user to load api spec like this:
```js
before(async() => {
    const apiSpec = (await axios.get('url/to/openapi/spec')).data;
    chai.use(chaiResponseValidator(apiSpec)); // no need to write out to a file
}
```

Also:
* minor clarification of test blocks
* minor corrections to the README