### PR TITLE
Release 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-openapi-response-validator",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:full": "npm run lint && npm run test:coverage && npm run test:mutation",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
-    "prepublish": "npm run test:full"
+    "prepublishOnly": "npm run test:full"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-openapi-response-validator",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Simple Chai support for asserting that HTTP responses satisfy an OpenAPI spec",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Features:
* User can define api spec directly as object https://github.com/RuntimeTools/chai-openapi-response-validator/pull/39, e.g.
```js
before(async() => {
    const apiSpec = (await axios.get('url/to/openapi/spec')).data;
    chai.use(chaiResponseValidator(apiSpec)); // no need to write out to a file
}
```