### PR TITLE
feat: user can validate objects against individual schemas

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -41,3 +41,5 @@ rules:
     - error
   keyword-spacing:
     - error
+  prefer-const:
+    - error

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ If your server's behaviour doesn't match your API documentation, then you need t
 This plugin lets you automatically test whether your server's behaviour and documentation match. It extends the [Chai Assertion Library](https://www.chaijs.com/) to support the [OpenAPI standard](https://swagger.io/docs/specification/about/) for documenting REST APIs.
 
 ## Features
-- Validates the status and body of HTTP responses against an OpenAPI spec
-- Load your OpenAPI spec just once in your tests (load from a [filepath](#load-openapi-spec-from-a-filepath) or [object](#load-openapi-spec-from-an-object))
+- Validate the status and body of HTTP responses against your OpenAPI spec [(see example)](#validate-the-status-and-body-of-http-responses-against-your-openapi-spec)
+- Validate objects against schemas defined in your OpenAPI spec [(see example)](#validate-objects-against-schemas-defined-in-your-OpenAPI-spec)
+- Load your OpenAPI spec just once in your tests
 - Supports OpenAPI [2](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md) and [3](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md)
 - Supports OpenAPI specs in YAML and JSON formats
 - Supports `$ref` in response definitions (i.e. `$ref: '#/definitions/ComponentType/ComponentName'`)
@@ -31,8 +32,9 @@ $ npm install --save-dev chai-openapi-response-validator
 
 ## Usage
 
-### 1. Write a test:
+### In API tests, validate the status and body of HTTP responses against your OpenAPI spec:
 
+#### 1. Write a test:
 ```javascript
 // Set up Chai
 const chai = require('chai');
@@ -59,7 +61,7 @@ describe('GET /example/endpoint', function() {
 });
 ```
 
-### 2. Write an OpenAPI Spec (and save to `path/to/openapi.yml`):
+#### 2. Write an OpenAPI Spec (and save to `path/to/openapi.yml`):
 ```yaml
 openapi: 3.0.0
 info:
@@ -83,39 +85,38 @@ paths:
                     type: string
                   integerProperty:
                     type: integer
-
 ```
 
-### 3. Run your test to validate your server's response against your OpenAPI spec:
+#### 3. Run your test to validate your server's response against your OpenAPI spec:
 
-#### The assertion passes if the response status and body satisfy `openapi.yml`:
+##### The assertion passes if the response status and body satisfy `openapi.yml`:
 
 ```javascript
 // Response includes:
 {
   status: 200,
   body: {
-    string: 'string',
-    integer: 123,
+    stringProperty: 'string',
+    integerProperty: 123,
   },
 };
 ```
 
 
-#### The assertion fails if the response body is invalid:
+##### The assertion fails if the response body is invalid:
 
 ```javascript
 // Response includes:
 {
   status: 200,
   body: {
-    string: 'string',
-    integer: 'invalid (should be an integer)',
+    stringProperty: 'string',
+    integerProperty: 'invalid (should be an integer)',
   },
 };
 ```
 
-##### Output from test failure:
+###### Output from test failure:
 
 ```javascript
 AssertionError: expected res to satisfy API spec:
@@ -138,7 +139,109 @@ AssertionError: expected res to satisfy API spec:
 }
 ```
 
-### Alternative step 1: load your OpenAPI spec from an object (instead of a filepath):
+### In unit tests, validate objects against schemas defined in your OpenAPI spec:
+#### 1. Write a test:
+```javascript
+// Set up Chai
+const chai = require('chai');
+const expect = chai.expect;
+
+// Import this plugin
+const chaiResponseValidator = require('chai-openapi-response-validator');
+
+// Load an OpenAPI file (YAML or JSON) into this plugin
+chai.use(chaiResponseValidator('path/to/openapi.yml'));
+
+// Write your test (e.g. using Mocha)
+describe('myModule.getObject()', function() {
+  it('should satisfy OpenAPI spec', async function() {
+    // Run the function you want to test
+    const myModule = require('path/to/your/module.js');
+    const output = myModule.getObject();
+
+    // Assert that the output satisfies a schema defined in your OpenAPI spec
+    expect(output).to.satisfySchemaInApiSpec('ExampleSchemaObject');
+  });
+});
+```
+
+#### 2. Write an OpenAPI Spec (and save to `path/to/openapi.yml`):
+```yaml
+openapi: 3.0.0
+info:
+  title: Example API
+  version: 1.0.0
+paths:
+  /example:
+    get:
+      responses:
+        200:
+          description: Response body should be an ExampleSchemaObject
+          content:
+            application/json:
+              schema: '#/components/schemas/ExampleSchemaObject'
+components:
+  schemas:
+    ExampleSchemaObject:
+      type: object
+      required:
+        - stringProperty
+        - integerProperty
+      properties:
+        stringProperty:
+          type: string
+        integerProperty:
+          type: integer
+```
+
+#### 3. Run your test to validate your object against your OpenAPI spec:
+
+##### The assertion passes if the object satisfies the schema `ExampleSchemaObject`:
+
+```javascript
+// object includes:
+{
+  stringProperty: 'string',
+  integerProperty: 123,
+};
+```
+
+
+##### The assertion fails if the object does not satisfy the schema `ExampleSchemaObject`:
+
+```javascript
+// object includes:
+{
+  stringProperty: 123,
+  integerProperty: 123,
+};
+```
+
+###### Output from test failure:
+
+```javascript
+AssertionError: expected object to satisfy schema 'ExampleSchemaObject' defined in API spec:
+{
+  message: 'The object was not valid.',
+  errors: [
+    {
+      errorCode: 'type.openapi.objectValidation',
+      message: 'stringProperty should be string'
+    }
+  ],
+  actualObject: {
+    {
+      stringProperty: 123,
+      integerProperty: 123
+    }
+  }
+}
+```
+
+### Loading your OpenAPI spec (3 different ways):
+
+#### 1. From an absolute filepath ([see above](#usage))
+#### 2. From an object:
 ```javascript
 // Set up Chai
 const chai = require('chai');
@@ -192,7 +295,7 @@ describe('GET /example/endpoint', function() {
 });
 ```
 
-#### This lets you load your OpenAPI spec from a web endpoint:
+#### 3. From a web endpoint:
 ```javascript
 // Set up Chai
 const chai = require('chai');

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ If your server's behaviour doesn't match your API documentation, then you need t
 This plugin lets you automatically test whether your server's behaviour and documentation match. It extends the [Chai Assertion Library](https://www.chaijs.com/) to support the [OpenAPI standard](https://swagger.io/docs/specification/about/) for documenting REST APIs.
 
 ## Features
-- Validate the status and body of HTTP responses against your OpenAPI spec [(see example)](#validate-the-status-and-body-of-http-responses-against-your-openapi-spec)
-- Validate objects against schemas defined in your OpenAPI spec [(see example)](#validate-objects-against-schemas-defined-in-your-OpenAPI-spec)
-- Load your OpenAPI spec just once in your tests
+- Validates the status and body of HTTP responses against your OpenAPI spec [(see example)](#in-api-tests-validate-the-status-and-body-of-http-responses-against-your-openapi-spec)
+- Validates objects against schemas defined in your OpenAPI spec [(see example)](#in-unit-tests-validate-objects-against-schemas-defined-in-your-OpenAPI-spec)
+- Load your OpenAPI spec just once in your tests (load from a filepath or object)
 - Supports OpenAPI [2](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md) and [3](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md)
 - Supports OpenAPI specs in YAML and JSON formats
 - Supports `$ref` in response definitions (i.e. `$ref: '#/definitions/ComponentType/ComponentName'`)

--- a/lib/classes/BaseOpenApiSpec.js
+++ b/lib/classes/BaseOpenApiSpec.js
@@ -102,8 +102,9 @@ class OpenApiSpec {
     }
 
     /*
-     * I don't know how to validate objects against schemas directly.
-     * So I put the object inside a mock response, then validate
+     * For consistency and to save maintaining another dependency,
+     * we validate objects using our response validator:
+     * We put the object inside a mock response, then validate
      * the whole response against a mock expected response.
      * The 2 mock responses are identical except for the body,
      * thus validating the object against its schema.

--- a/lib/classes/BaseOpenApiSpec.js
+++ b/lib/classes/BaseOpenApiSpec.js
@@ -2,6 +2,11 @@ const OpenAPIResponseValidator = require('openapi-response-validator').default;
 
 const { extractPathname } = require('./Response');
 
+const toOpenapiModelValidationError = (error) => ({
+  errorCode: 'type.openapi.objectValidation',
+  message: error.message.replace('response', 'object'),
+});
+
 class OpenApiSpec {
   constructor(spec) {
     this.spec = spec;
@@ -24,6 +29,11 @@ class OpenApiSpec {
     return Object.keys(this.pathsObject());
   }
 
+  getSchemaObject(schemaName) {
+    const schemaObjects = this.getSchemaObjects();
+    return schemaObjects[schemaName];
+  }
+
   /**
    * @returns {ResponseObject} ResponseObject
    * @see OpenAPI2 {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#response-object}
@@ -35,8 +45,8 @@ class OpenApiSpec {
 
     const status = actualResponse.status();
     let expectedResponse = expectedResponseOperation.responses[status];
-    if (expectedResponse && expectedResponse['$ref']) {
-      expectedResponse = this.findResponseDefinition(expectedResponse['$ref']);
+    if (expectedResponse && expectedResponse.$ref) {
+      expectedResponse = this.findResponseDefinition(expectedResponse.$ref);
     }
     if (!expectedResponse) {
       throw new Error(`No '${status}' response defined for endpoint '${actualRequest.method} ${this.findOpenApiPathMatchingRequest(actualRequest)}' in OpenAPI spec`);
@@ -67,10 +77,11 @@ class OpenApiSpec {
     return operationObject;
   }
 
-  validateResponse(actualResponse, expectedResponse) {
+  validateResponse(actualResponse) {
+    const expectedResponse = this.findExpectedResponse(actualResponse);
     const resValidator = new OpenAPIResponseValidator({
       responses: expectedResponse,
-      ...this.getVersionSpecificValidatorOptions(),
+      ...this.getComponentDefinitionsProperty(),
     });
 
     const [expectedResStatus] = Object.keys(expectedResponse);
@@ -78,6 +89,40 @@ class OpenApiSpec {
       expectedResStatus,
       actualResponse.getBodyForValidation(),
     );
+    if (validationError) {
+      validationError.actualResponse = actualResponse.summary();
+    }
+    return validationError;
+  }
+
+  validateObject(actualObject, schemaName) {
+    const schema = this.getSchemaObject(schemaName);
+    if (!schema) {
+      throw new Error(`No schema named '${schemaName}' in OpenAPI spec`);
+    }
+
+    /*
+     * I don't know how to validate objects against schemas directly.
+     * So I put the object inside a mock response, then validate
+     * the whole response against a mock expected response.
+     * The 2 mock responses are identical except for the body,
+     * thus validating the object against its schema.
+     */
+    const mockResStatus = 200;
+    const mockExpectedResponse = { [mockResStatus]: { schema } };
+    const resValidator = new OpenAPIResponseValidator({
+      responses: mockExpectedResponse,
+      ...this.getComponentDefinitionsProperty(),
+      errorTransformer: toOpenapiModelValidationError,
+    });
+    const validationError = resValidator.validateResponse(
+      mockResStatus,
+      actualObject,
+    );
+    if (validationError) {
+      validationError.message = validationError.message.replace('response', 'object');
+      validationError.actualObject = actualObject;
+    }
     return validationError;
   }
 }

--- a/lib/classes/OpenApi2Spec.js
+++ b/lib/classes/OpenApi2Spec.js
@@ -28,8 +28,16 @@ class OpenApi2Spec extends OpenApiSpec {
   /**
    * @see DefinitionsObject {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#definitions-object}
    */
-  getVersionSpecificValidatorOptions() {
-    return { definitions: this.spec.definitions };
+  getComponentDefinitions() {
+    return this.spec.definitions;
+  }
+
+  getComponentDefinitionsProperty() {
+    return { definitions: this.getComponentDefinitions() };
+  }
+
+  getSchemaObjects() {
+    return this.getComponentDefinitions();
   }
 }
 

--- a/lib/classes/OpenApi2Spec.js
+++ b/lib/classes/OpenApi2Spec.js
@@ -18,7 +18,8 @@ class OpenApi2Spec extends OpenApiSpec {
   }
 
   /**
-   * @returns {ResponseObject} ResponseObject {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#responses-definitions-object}
+   * @returns {ResponseObject} ResponseObject
+   * {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#responses-definitions-object}
    */
   findResponseDefinition(referenceString) {
     const nameOfResponseDefinition = referenceString.split('#/responses/')[1];
@@ -26,7 +27,8 @@ class OpenApi2Spec extends OpenApiSpec {
   }
 
   /**
-   * @see DefinitionsObject {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#definitions-object}
+   * @returns {[DefinitionsObject]} DefinitionsObject
+   * {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#definitions-object}
    */
   getComponentDefinitions() {
     return this.spec.definitions;

--- a/lib/classes/OpenApi3Spec.js
+++ b/lib/classes/OpenApi3Spec.js
@@ -83,7 +83,8 @@ class OpenApi3Spec extends OpenApiSpec {
   }
 
   /**
-   * @returns {ResponseObject} ResponseObject {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsResponses}
+   * @returns {ResponseObject} ResponseObject
+   * {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsResponses}
    */
   findResponseDefinition(referenceString) {
     const nameOfResponseDefinition = referenceString.split('#/components/responses/')[1];
@@ -91,7 +92,8 @@ class OpenApi3Spec extends OpenApiSpec {
   }
 
   /**
-   * @see ComponentsObject {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsObject}
+   * @returns {[ComponentsObject]} ComponentsObject
+   * {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsObject}
    */
   getComponentDefinitions() {
     return this.spec.components;

--- a/lib/classes/OpenApi3Spec.js
+++ b/lib/classes/OpenApi3Spec.js
@@ -93,8 +93,16 @@ class OpenApi3Spec extends OpenApiSpec {
   /**
    * @see ComponentsObject {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsObject}
    */
-  getVersionSpecificValidatorOptions() {
-    return { components: this.spec.components };
+  getComponentDefinitions() {
+    return this.spec.components;
+  }
+
+  getComponentDefinitionsProperty() {
+    return { components: this.getComponentDefinitions() };
+  }
+
+  getSchemaObjects() {
+    return this.getComponentDefinitions().schemas;
   }
 }
 

--- a/lib/classes/Response.js
+++ b/lib/classes/Response.js
@@ -77,5 +77,7 @@ const extractPathname = (actualRequest) => {
   return pathname;
 };
 
-module.exports = Response;
-module.exports.extractPathname = extractPathname;
+module.exports = {
+  Response,
+  extractPathname,
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@
  *******************************************************************************/
 
 const { stringify } = require('./utils');
+const { Response } = require('./classes/Response');
 const openApiSpecFactory = require('./openApiSpecFactory');
 
 module.exports = function (filepathOrObject) {
@@ -27,12 +28,7 @@ module.exports = function (filepathOrObject) {
       const actualResponse = new Response(this._obj);
       const actualRequest = actualResponse.req();
 
-      const expectedResponse = openApiSpec.findExpectedResponse(actualResponse);
-
-      const validationError = openApiSpec.validateResponse(actualResponse, expectedResponse);
-      if (validationError) {
-        validationError.actualResponse = actualResponse.summary();
-      }
+      const validationError = openApiSpec.validateResponse(actualResponse);
 
       this.assert(
         !validationError,

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,8 +14,7 @@
  * limitations under the License.
  *******************************************************************************/
 
-const utils = require('./utils');
-const Response = require('./classes/Response');
+const { stringify } = require('./utils');
 const openApiSpecFactory = require('./openApiSpecFactory');
 
 module.exports = function (filepathOrObject) {
@@ -37,10 +36,23 @@ module.exports = function (filepathOrObject) {
 
       this.assert(
         !validationError,
-        `expected res to satisfy API spec:\n${utils.stringify(validationError)}`,
+        `expected res to satisfy API spec:\n${stringify(validationError)}`,
         `expected res not to satisfy API spec for '${actualResponse.status()}' response`
-          + ` defined for endpoint '${actualRequest.method} ${openApiSpec.findOpenApiPathMatchingRequest(actualRequest)}'`
-          + ` in OpenAPI spec\nres: ${actualResponse.toString()}`,
+        + ` defined for endpoint '${actualRequest.method} ${openApiSpec.findOpenApiPathMatchingRequest(actualRequest)}'`
+        + ` in OpenAPI spec\nres: ${actualResponse.toString()}`,
+      );
+    });
+
+    Assertion.addMethod('satisfySchemaInApiSpec', function (schemaName) {
+      const actualObject = this._obj;
+
+      const validationError = openApiSpec.validateObject(actualObject, schemaName);
+
+      this.assert(
+        !validationError,
+        `expected object to satisfy schema '${schemaName}' defined in API spec:\n${stringify(validationError)}`,
+        `expected object not to satisfy schema '${schemaName}'`
+          + ` defined in OpenAPI spec\nobject: ${stringify(actualObject)}`
       );
     });
   };

--- a/test/resources/exampleOpenApiFiles/valid/satisfySchemaInApiSpec/openapi2.json
+++ b/test/resources/exampleOpenApiFiles/valid/satisfySchemaInApiSpec/openapi2.json
@@ -1,0 +1,71 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Has various paths with responses to use in testing",
+    "title": "Example OpenApi 3 spec",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/unused": {
+      "get": {
+        "parameters": [],
+        "responses": {
+          "204": {
+            "description": "No response body"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "IntegerSchema": {
+      "type": "integer"
+    },
+    "SchemaReferencingAnotherSchema": {
+      "properties": {
+        "property1": {
+          "$ref": "#/definitions/StringSchema"
+        }
+      },
+      "required": [
+        "property1"
+      ]
+    },
+    "SchemaUsingAllOf": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SimpleObjectSchema"
+        },
+        {
+          "$ref": "#/definitions/SimpleObjectSchemaWithDifferentPropertyName"
+        }
+      ]
+    },
+    "SimpleObjectSchema": {
+      "properties": {
+        "property1": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "property1"
+      ],
+      "type": "object"
+    },
+    "SimpleObjectSchemaWithDifferentPropertyName": {
+      "properties": {
+        "property2": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "property2"
+      ],
+      "type": "object"
+    },
+    "StringSchema": {
+      "type": "string"
+    }
+  },
+  "x-components": {}
+}

--- a/test/resources/exampleOpenApiFiles/valid/satisfySchemaInApiSpec/openapi3.yml
+++ b/test/resources/exampleOpenApiFiles/valid/satisfySchemaInApiSpec/openapi3.yml
@@ -1,0 +1,49 @@
+openapi: 3.0.0
+info:
+  title: Example OpenApi 3 spec
+  description: Has various paths with responses to use in testing
+  version: 0.1.0
+paths:
+  /unused:
+    get:
+      responses:
+        204:
+          description: No response body
+components:
+  schemas:
+    StringSchema:
+      type: string
+    IntegerSchema:
+      type: integer
+    SimpleObjectSchema:
+      type: object
+      required:
+      - property1
+      properties:
+        property1:
+          type: string
+    SimpleObjectSchemaWithDifferentPropertyName:
+      type: object
+      required:
+      - property2
+      properties:
+        property2:
+          type: string
+    SchemaReferencingAnotherSchema:
+      required:
+      - property1
+      properties:
+        property1:
+          $ref: '#/components/schemas/StringSchema'
+    SchemaUsingAllOf:
+      allOf:
+      - $ref: '#/components/schemas/SimpleObjectSchema'
+      - $ref: '#/components/schemas/SimpleObjectSchemaWithDifferentPropertyName'
+    SchemaUsingAnyOf:
+      anyOf:
+      - $ref: '#/components/schemas/SimpleObjectSchema'
+      - $ref: '#/components/schemas/SimpleObjectSchemaWithDifferentPropertyName'
+    SchemaUsingOneOf:
+      oneOf:
+      - $ref: '#/components/schemas/SimpleObjectSchema'
+      - $ref: '#/components/schemas/SimpleObjectSchemaWithDifferentPropertyName'

--- a/test/unit/assertions/satisfyApiSpec.test.js
+++ b/test/unit/assertions/satisfyApiSpec.test.js
@@ -20,14 +20,15 @@ const util = require('util');
 
 const chaiResponseValidator = require('../../..');
 
+const openApiSpecsDir = path.resolve('test', 'resources', 'exampleOpenApiFiles', 'valid');
 const openApiSpecs = [
   {
     openApiVersion: 2,
-    pathToApiSpec: path.resolve('test/resources/exampleOpenApiFiles/valid/openapi2.json'),
+    pathToApiSpec: path.join(openApiSpecsDir, 'openapi2.json'),
   },
   {
     openApiVersion: 3,
-    pathToApiSpec: path.resolve('test/resources/exampleOpenApiFiles/valid/openapi3.yml'),
+    pathToApiSpec: path.join(openApiSpecsDir, 'openapi3.yml'),
   },
 ];
 const { expect } = chai;

--- a/test/unit/assertions/satisfySchemaInApiSpec.test.js
+++ b/test/unit/assertions/satisfySchemaInApiSpec.test.js
@@ -1,0 +1,383 @@
+const chai = require('chai');
+const path = require('path');
+const { inspect } = require('util');
+
+const chaiResponseValidator = require('../../..');
+
+const openApiSpecsDir = path.resolve('test', 'resources', 'exampleOpenApiFiles', 'valid', 'satisfySchemaInApiSpec');
+const openApiSpecs = [
+  {
+    openApiVersion: 2,
+    pathToApiSpec: path.join(openApiSpecsDir, 'openapi2.json'),
+  },
+  {
+    openApiVersion: 3,
+    pathToApiSpec: path.join(openApiSpecsDir, 'openapi3.yml'),
+  },
+];
+
+const { expect } = chai;
+
+for (const spec of openApiSpecs) {
+  const { openApiVersion, pathToApiSpec } = spec;
+
+  describe(`expect(obj).to.satisfySchemaInApiSpec(schemaName) (using an OpenAPI ${openApiVersion} spec)`, function () {
+
+    before(function () {
+      chai.use(chaiResponseValidator(pathToApiSpec));
+    });
+
+    describe('when \'obj\' matches a schema defined in the API spec, such that spec expects obj to', function () {
+
+      describe('be a string', function () {
+        const schemaName = 'StringSchema';
+
+        describe('\'obj\' satisfies the spec', function () {
+          const validObj = 'string';
+
+          it('passes', function () {
+            expect(validObj).to.satisfySchemaInApiSpec(schemaName);
+          });
+
+          it('fails when using .not', function () {
+            const assertion = () =>
+              expect(validObj).to.not.satisfySchemaInApiSpec(schemaName);
+            expect(assertion).to.throw(
+              `expected object not to satisfy schema '${schemaName}'`
+                + ` defined in OpenAPI spec\nobject: ${inspect(validObj)}`
+            );
+          });
+        });
+
+        describe('\'obj\' does not satisfy the spec', function () {
+          const invalidObj = 123;
+
+          it('fails and outputs a useful error message', function () {
+            const assertion = () =>
+              expect(invalidObj).to.satisfySchemaInApiSpec(schemaName);
+            expect(assertion).to.throw(
+              `expected object to satisfy schema '${schemaName}' defined in API spec:\n${inspect({
+                message: 'The object was not valid.',
+                errors: [
+                  {
+                    errorCode: 'type.openapi.objectValidation',
+                    message: 'object should be string',
+                  },
+                ],
+                actualObject: invalidObj,
+              })}`
+            );
+          });
+
+          it('passes when using .not', function () {
+            expect(invalidObj).to.not.satisfySchemaInApiSpec(schemaName);
+          });
+        });
+      });
+
+      describe('be an integer', function () {
+        const schemaName = 'IntegerSchema';
+
+        describe('\'obj\' satisfies the spec', function () {
+          const validObj = 123;
+
+          it('passes', function () {
+            expect(validObj).to.satisfySchemaInApiSpec(schemaName);
+          });
+
+          it('fails when using .not', function () {
+            const assertion = () =>
+              expect(validObj).to.not.satisfySchemaInApiSpec(schemaName);
+            expect(assertion).to.throw(
+              `expected object not to satisfy schema '${schemaName}'`
+                + ` defined in OpenAPI spec\nobject: ${inspect(validObj)}`
+            );
+          });
+        });
+
+        describe('\'obj\' does not satisfy the spec', function () {
+          const invalidObj = 'should be integer';
+
+          it('fails and outputs a useful error message', function () {
+            const assertion = () =>
+              expect(invalidObj).to.satisfySchemaInApiSpec(schemaName);
+            expect(assertion).to.throw(
+              `expected object to satisfy schema '${schemaName}' defined in API spec:\n${inspect({
+                message: 'The object was not valid.',
+                errors: [
+                  {
+                    errorCode: 'type.openapi.objectValidation',
+                    message: 'object should be integer',
+                  },
+                ],
+                actualObject: invalidObj,
+              })}`
+            );
+          });
+
+          it('passes when using .not', function () {
+            expect(invalidObj).to.not.satisfySchemaInApiSpec(schemaName);
+          });
+        });
+      });
+
+      describe('be a simple object', function () {
+        const schemaName = 'SimpleObjectSchema';
+
+        describe('\'obj\' satisfies the spec', function () {
+          const validObj = { property1: 'string' };
+
+          it('passes', function () {
+            expect(validObj).to.satisfySchemaInApiSpec(schemaName);
+          });
+
+          it('fails when using .not', function () {
+            const assertion = () =>
+              expect(validObj).to.not.satisfySchemaInApiSpec(schemaName);
+            expect(assertion).to.throw(
+              `expected object not to satisfy schema '${schemaName}'`
+                + ` defined in OpenAPI spec\nobject: ${inspect(validObj)}`
+            );
+          });
+        });
+
+        describe('\'obj\' does not satisfy the spec', function () {
+          const invalidObj = { property1: 123 };
+
+          it('fails and outputs a useful error message', function () {
+            const assertion = () =>
+              expect(invalidObj).to.satisfySchemaInApiSpec(schemaName);
+            expect(assertion).to.throw(
+              `expected object to satisfy schema '${schemaName}' defined in API spec:\n${inspect({
+                message: 'The object was not valid.',
+                errors: [
+                  {
+                    errorCode: 'type.openapi.objectValidation',
+                    message: 'property1 should be string',
+                  },
+                ],
+                actualObject: invalidObj,
+              })}`
+            );
+          });
+
+          it('passes when using .not', function () {
+            expect(invalidObj).to.not.satisfySchemaInApiSpec(schemaName);
+          });
+        });
+      });
+
+      describe('satisfy a schema referencing another schema', function () {
+        const schemaName = 'SchemaReferencingAnotherSchema';
+
+        describe('\'obj\' satisfies the spec', function () {
+          const validObj = { property1: 'string' };
+
+          it('passes', function () {
+            expect(validObj).to.satisfySchemaInApiSpec(schemaName);
+          });
+
+          it('fails when using .not', function () {
+            const assertion = () =>
+              expect(validObj).to.not.satisfySchemaInApiSpec(schemaName);
+            expect(assertion).to.throw(
+              `expected object not to satisfy schema '${schemaName}'`
+                + ` defined in OpenAPI spec\nobject: ${inspect(validObj)}`
+            );
+          });
+        });
+
+        describe('\'obj\' does not satisfy the spec', function () {
+          const invalidObj = { property1: 123 };
+
+          it('fails and outputs a useful error message', function () {
+            const assertion = () =>
+              expect(invalidObj).to.satisfySchemaInApiSpec(schemaName);
+            expect(assertion).to.throw(
+              `expected object to satisfy schema '${schemaName}' defined in API spec:\n${inspect({
+                message: 'The object was not valid.',
+                errors: [
+                  {
+                    errorCode: 'type.openapi.objectValidation',
+                    message: 'property1 should be string',
+                  },
+                ],
+                actualObject: invalidObj,
+              })}`
+            );
+          });
+
+          it('passes when using .not', function () {
+            expect(invalidObj).to.not.satisfySchemaInApiSpec(schemaName);
+          });
+        });
+      });
+
+      describe('satisfy allOf 2 schemas', function () {
+        const schemaName = 'SchemaUsingAllOf';
+
+        describe('\'obj\' satisfies the spec', function () {
+          const validObj = { property1: 'string', property2: 'string' };
+
+          it('passes', function () {
+            expect(validObj).to.satisfySchemaInApiSpec(schemaName);
+          });
+
+          it('fails when using .not', function () {
+            const assertion = () =>
+              expect(validObj).to.not.satisfySchemaInApiSpec(schemaName);
+            expect(assertion).to.throw(
+              `expected object not to satisfy schema '${schemaName}'`
+                + ` defined in OpenAPI spec\nobject: ${inspect(validObj)}`
+            );
+          });
+        });
+
+        describe('\'obj\' does not satisfy the spec', function () {
+          const invalidObj = { property1: 'string', property2: 123 };
+
+          it('fails and outputs a useful error message', function () {
+            const assertion = () =>
+              expect(invalidObj).to.satisfySchemaInApiSpec(schemaName);
+            expect(assertion).to.throw(
+              `expected object to satisfy schema '${schemaName}' defined in API spec:\n${inspect({
+                message: 'The object was not valid.',
+                errors: [
+                  {
+                    errorCode: 'type.openapi.objectValidation',
+                    message: 'property2 should be string',
+                  },
+                ],
+                actualObject: invalidObj,
+              })}`
+            );
+          });
+
+          it('passes when using .not', function () {
+            expect(invalidObj).to.not.satisfySchemaInApiSpec(schemaName);
+          });
+        });
+      });
+
+      if (openApiVersion === 3) {
+        describe('satisfy anyOf 2 schemas', function () {
+          const schemaName = 'SchemaUsingAnyOf';
+
+          describe('\'obj\' satisfies the spec', function () {
+            const validObj = { property1: 123, property2: 'string' };
+
+            it('passes', function () {
+              expect(validObj).to.satisfySchemaInApiSpec(schemaName);
+            });
+
+            it('fails when using .not', function () {
+              const assertion = () =>
+                expect(validObj).to.not.satisfySchemaInApiSpec(schemaName);
+              expect(assertion).to.throw(
+                `expected object not to satisfy schema '${schemaName}'`
+                  + ` defined in OpenAPI spec\nobject: ${inspect(validObj)}`
+              );
+            });
+          });
+
+          describe('\'obj\' does not satisfy the spec', function () {
+            const invalidObj = { property1: 123, property2: 123 };
+
+            it('fails and outputs a useful error message', function () {
+              const assertion = () =>
+                expect(invalidObj).to.satisfySchemaInApiSpec(schemaName);
+              expect(assertion).to.throw(
+                `expected object to satisfy schema '${schemaName}' defined in API spec:\n${inspect({
+                  message: 'The object was not valid.',
+                  errors: [
+                    {
+                      errorCode: 'type.openapi.objectValidation',
+                      message: 'property1 should be string',
+                    },
+                    {
+                      errorCode: 'type.openapi.objectValidation',
+                      message: 'property2 should be string',
+                    },
+                    {
+                      errorCode: 'type.openapi.objectValidation',
+                      message: 'object should match some schema in anyOf',
+                    },
+                  ],
+                  actualObject: { property1: 123, property2: 123 },
+                })}`
+              );
+            });
+
+            it('passes when using .not', function () {
+              expect(invalidObj).to.not.satisfySchemaInApiSpec(schemaName);
+            });
+          });
+        });
+
+        describe('satisfy oneOf 2 schemas', function () {
+          const schemaName = 'SchemaUsingOneOf';
+
+          describe('\'obj\' satisfies the spec', function () {
+            const validObj = { property1: 123, property2: 'string' };
+
+            it('passes', function () {
+              expect(validObj).to.satisfySchemaInApiSpec(schemaName);
+            });
+
+            it('fails when using .not', function () {
+              const assertion = () =>
+                expect(validObj).to.not.satisfySchemaInApiSpec(schemaName);
+              expect(assertion).to.throw(
+                `expected object not to satisfy schema '${schemaName}'`
+                  + ` defined in OpenAPI spec\nobject: ${inspect(validObj)}`
+              );
+            });
+          });
+
+          describe('\'obj\' does not satisfy the spec', function () {
+            const invalidObj = { property1: 'string', property2: 'string' };
+
+            it('fails and outputs a useful error message', function () {
+              const assertion = () =>
+                expect(invalidObj).to.satisfySchemaInApiSpec(schemaName);
+              expect(assertion).to.throw(
+                `expected object to satisfy schema '${schemaName}' defined in API spec:\n${inspect({
+                  message: 'The object was not valid.',
+                  errors: [
+                    {
+                      errorCode: 'type.openapi.objectValidation',
+                      message: 'object should match exactly one schema in oneOf',
+                    },
+                  ],
+                  actualObject: invalidObj,
+                })}`
+              );
+            });
+
+            it('passes when using .not', function () {
+              expect(invalidObj).to.not.satisfySchemaInApiSpec(schemaName);
+            });
+          });
+        });
+      }
+    });
+
+    describe('when \'obj\' matches NO schemas defined in the API spec', function () {
+      const obj = 'foo';
+
+      it('fails', function () {
+        const assertion = () =>
+          expect(obj).to.satisfySchemaInApiSpec('NonExistentSchema');
+        expect(assertion).to.throw('No schema named \'NonExistentSchema\' in OpenAPI spec');
+      });
+
+      it('fails when using .not', function () {
+        const assertion = () =>
+          expect(obj).to.satisfySchemaInApiSpec('NonExistentSchema');
+        expect(assertion).to.throw('No schema named \'NonExistentSchema\' in OpenAPI spec');
+      });
+    });
+
+  });
+
+}


### PR DESCRIPTION
for https://github.com/RuntimeTools/chai-openapi-response-validator/issues/38

* see the updated README for what feature this PR adds.
* corrects a tiny mistake in the docs (`string` -> `stringProperty`)

### Note the following workaround:
Note the comment about how I've implemented the validation:
```
* I don't know how to validate objects against schemas directly.
* So I put the object inside a mock response, then validate
* the whole response against a mock expected response.
* The 2 mock responses are identical except for the body,
* thus validating the object against its schema.
```
The only package I found allowing us to validate the object directly (rather than validating an entire response object) was [swagger-model-validator](https://github.com/swagger-model-validator/swagger-model-validator). 

However, this did not work in a number of cases (I opened issues 120, 121, 122 at https://github.com/swagger-model-validator/swagger-model-validator/issues), and the error messages were less clear than the validator we already use (openapi-response-validator). 

Therefore I used this workaround to maintain consistency and quality for little time investment
