### PR TITLE
Release 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-openapi-response-validator",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-openapi-response-validator",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Simple Chai support for asserting that HTTP responses satisfy an OpenAPI spec",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Resolves #38 

Features:
* Users can now validate objects against individual schema objects https://github.com/RuntimeTools/chai-openapi-response-validator/issues/38, e.g.:

Given an API spec including:
```
...
components:
  schemas:
    ExampleSchemaObject:
      type: string
...
```
Assert in unit tests:
```js
expect('foo').to.satisfySchemaDefinedInApiSpec('ExampleSchemaObject') // passes
expect(['foo']).to.satisfySchemaDefinedInApiSpec('ExampleSchemaObject') // throws useful error 
```
For a fuller guide, see docs from [master](https://github.com/RuntimeTools/chai-openapi-response-validator#in-unit-tests-validate-objects-against-schemas-defined-in-your-OpenAPI-spec) or [the original PR](https://github.com/RuntimeTools/chai-openapi-response-validator/pull/42/files#diff-04c6e90faac2675aa89e2176d2eec7d8R142)