### PR TITLE
Alter body retrieval to '=== undefined' for response-provider checks

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,3 +2,4 @@ Authors ordered by first contribution:
 
  - Richard Waller (https://github.com/rwalle61)
  - Jonny Spruce (https://github.com/JonnySpruce)
+ - Alex Dobeck (https://github.com/AlexDobeck)

--- a/lib/classes/Response.js
+++ b/lib/classes/Response.js
@@ -17,8 +17,9 @@ class Response {
   }
 
   body() {
-    let body = this.res.body // for all modules except axios
-      || this.res.data // for axios
+    let body = this.res.body !== undefined
+      ? this.res.body // for all modules except axios
+      : this.res.data // for axios
       ;
     if (typeof body == 'string') {
       body = body.replace(/"/g, '');

--- a/test/resources/exampleApp.js
+++ b/test/resources/exampleApp.js
@@ -11,6 +11,14 @@ app.get('/test/header/application/json/and/responseBody/emptyObject', (req, res)
   res.send({})
 );
 
+app.get('/test/header/application/json/and/responseBody/boolean', (req, res) =>
+  res.json(false)
+);
+
+app.get('/test/header/application/json/and/responseBody/nullable', (req, res) =>
+  res.json(null)
+);
+
 app.get('/test/header/text/html', (req, res) =>
   res.send('res.body is a string')
 );

--- a/test/resources/exampleOpenApiFiles/valid/openapi2.json
+++ b/test/resources/exampleOpenApiFiles/valid/openapi2.json
@@ -166,6 +166,22 @@
         }
       }
     },
+    "/test/responseBody/boolean": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Response body should be a boolean",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
     "/test/responseStatus": {
       "get": {
         "parameters": [],

--- a/test/resources/exampleOpenApiFiles/valid/openapi3.yml
+++ b/test/resources/exampleOpenApiFiles/valid/openapi3.yml
@@ -13,6 +13,15 @@ paths:
             application/json:
               schema:
                 type: string
+  /test/responseBody/boolean:
+    get:
+      responses:
+        200:
+          description: Response body should be a boolean
+          content:
+            application/json:
+              schema:
+                type: boolean
   /test/responseBody/referencesSchemaObject:
     get:
       responses:
@@ -120,6 +129,25 @@ paths:
             application/json:
               schema:
                 type: object
+  /test/header/application/json/and/responseBody/boolean:
+    get:
+      responses:
+        200:
+          description: Response header is application/json, and response body is a boolean.
+          content:
+            application/json:
+              schema:
+                type: boolean
+  /test/header/application/json/and/responseBody/nullable:
+    get:
+      responses:
+        200:
+          description: Response header is application/json, and response body is nullable.
+          content:
+            application/json:
+              schema:
+                type: object
+                nullable: true
   /test/header/text/html:
     get:
       responses:

--- a/test/unit/assertions/differentRequestModules.test.js
+++ b/test/unit/assertions/differentRequestModules.test.js
@@ -78,6 +78,42 @@ describe('Parsing responses from different request modules', function () {
       });
     });
 
+    describe('res header is application/json, and res.body is a boolean (false)', function() {
+      const res = chai.request(app).get('/test/header/application/json/and/responseBody/boolean');
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/header/application/json/and/responseBody/boolean' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 200,
+              body: false,
+            })
+          }`
+        );
+      });
+    });
+
+    describe('res header is application/json, and res.body is a null', function() {
+      const res = chai.request(app).get('/test/header/application/json/and/responseBody/nullable');
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/header/application/json/and/responseBody/nullable' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 200,
+              body: null,
+            })
+          }`
+        );
+      });
+    });
+
     describe('res header is text/html, res.body is {}, and res.text is a string', function() {
       const res = chai.request(app).get('/test/header/text/html');
       it('passes', async function() {

--- a/test/unit/assertions/satisfyApiSpec.test.js
+++ b/test/unit/assertions/satisfyApiSpec.test.js
@@ -108,6 +108,33 @@ for (const spec of openApiSpecs) {
               expect(assertion).to.throw('expected res not to satisfy API spec for \'204\' response defined for endpoint \'GET /test/responseBody/empty\' in OpenAPI spec');
             });
           });
+
+          describe('be a boolean', function () {
+            const res = {
+              status: 200,
+              req: {
+                method: 'GET',
+                path: '/test/responseBody/boolean',
+              },
+              body: false,
+            };
+
+            it('passes', function () {
+              expect(res).to.satisfyApiSpec;
+            });
+
+            it('fails when using .not', function () {
+              const assertion = () => expect(res).to.not.satisfyApiSpec;
+              expect(assertion).to.throw(
+                `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/responseBody/boolean' in OpenAPI spec\nres: ${
+                  util.inspect({
+                    status: 200,
+                    body: false,
+                  })
+                }`
+              );
+            });
+          });
         });
 
         describe('res.req.path matches a response referencing a response definition', function () {


### PR DESCRIPTION
This is a proposed resolution to: 
https://github.com/RuntimeTools/chai-openapi-response-validator/issues/49


The (this.res.body) falsey check is failing for potentially valid falsey values (false, null), returning 'undefined' for non-axios request providers.