### PR TITLE
fix, test: correctly validate stringified null res.body for request-promise

### DIFF
--- a/lib/classes/Response.js
+++ b/lib/classes/Response.js
@@ -38,7 +38,7 @@ class Response {
     // for request-promise
     try {
       const parsedBody = JSON.parse(body);
-      if (utils.isEmptyObj(parsedBody)) {
+      if (utils.isEmptyObj(parsedBody) || parsedBody === null) {
         return parsedBody;
       }
     } catch (error) {

--- a/test/unit/assertions/differentRequestModules.test.js
+++ b/test/unit/assertions/differentRequestModules.test.js
@@ -192,6 +192,24 @@ describe('Parsing responses from different request modules', function () {
       });
     });
 
+    describe('res header is application/json, and res.body is a null', function() {
+      const res = supertest(app).get('/test/header/application/json/and/responseBody/nullable');
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/header/application/json/and/responseBody/nullable' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 200,
+              body: null,
+            })
+          }`
+        );
+      });
+    });
+
   });
 
   describe('axios', function() {
@@ -244,6 +262,24 @@ describe('Parsing responses from different request modules', function () {
             util.inspect({
               status: 200,
               body: 'res.body is a string',
+            })
+          }`
+        );
+      });
+    });
+
+    describe('res header is application/json, and res.body is a null', function() {
+      const res = axios.get(`${appOrigin}/test/header/application/json/and/responseBody/nullable`);
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/header/application/json/and/responseBody/nullable' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 200,
+              body: null,
             })
           }`
         );
@@ -333,6 +369,28 @@ describe('Parsing responses from different request modules', function () {
             util.inspect({
               status: 200,
               body: 'res.body is a string',
+            })
+          }`
+        );
+      });
+    });
+
+    describe('res header is application/json, and res.body is a null', function() {
+      const res = requestPromise({
+        method: 'GET',
+        uri: `${appOrigin}/test/header/application/json/and/responseBody/nullable`,
+        resolveWithFullResponse: true,
+      });
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '200' response defined for endpoint 'GET /test/header/application/json/and/responseBody/nullable' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 200,
+              body: 'null',
             })
           }`
         );


### PR DESCRIPTION
When https://github.com/RuntimeTools/chai-openapi-response-validator/issues/49 was fixed we only checked that we correctly validated falsy response bodies when making requests with chai-http.

It turns out that we were incorrectly validating `null` response bodies when making requests with request-promise.

 [When an Express server responds with `res.json(null)`, the response has header `application/json` and the body is JSON.stringified to `'null'`](https://expressjs.com/en/api.html#res.json). Other request modules seem to treat these response bodies as null, but request-promise treats this response body (most accurately) as `'null'`. 

Therefore we were forcing users who did this to say in the OpenAPI spec that their response body is a string. But I think users want to say instead that their response body is [`nullable`](https://swagger.io/docs/specification/data-models/data-types/) (this was the motivation for https://github.com/RuntimeTools/chai-openapi-response-validator/issues/49)

This PR fixes that. It also adds tests to check that we correctly validate null response bodies for all our supported request packages.

If I have misunderstood what users want to do, let me know and we can revert this change or edit it in a different way

PS
The Response class is increasingly getting overloaded with conditional logic depending on which request module returns the response. It may be worth refactoring to separate that logic into new child classes: SuperagentResponse, AxiosResponse, and RequestPromiseResponse. 