### PR TITLE
fix: correctly validate responses without bodies

### DIFF
--- a/lib/classes/Response.js
+++ b/lib/classes/Response.js
@@ -27,7 +27,22 @@ class Response {
     return body;
   }
 
+  hasNoBody() {
+    const hasNoContentTypeHeader = this.res.hasOwnProperty('headers')
+      && !this.res.headers.hasOwnProperty('content-type');
+    const bodyHasNoContent = (
+      this.res.text === '' // for superagent-based request modules
+      || this.res.data === '' // for axios
+      || this.res.body === '' // for request-promise
+    );
+    return (hasNoContentTypeHeader && bodyHasNoContent);
+  }
+
   getBodyForValidation() {
+    if (this.hasNoBody()) {
+      return null;
+    }
+
     // for superagent-based request modules
     if (this.isResTextPopulatedInsteadOfResBody) {
       return this.res.text;

--- a/test/resources/exampleApp.js
+++ b/test/resources/exampleApp.js
@@ -23,6 +23,10 @@ app.get('/test/header/text/html', (req, res) =>
   res.send('res.body is a string')
 );
 
+app.get('/test/no/content-type/header/and/no/response/body', (req, res) =>
+  res.sendStatus(204)
+);
+
 app.listen(
   port,
   // () => console.log(`Test app listening on port ${port}.`),

--- a/test/resources/exampleOpenApiFiles/valid/openapi3.yml
+++ b/test/resources/exampleOpenApiFiles/valid/openapi3.yml
@@ -157,6 +157,11 @@ paths:
             text/html:
               schema:
                 type: string
+  /test/no/content-type/header/and/no/response/body:
+    get:
+      responses:
+        204:
+          description: No content-type response header, and there is no response body
 components:
   schemas:
     ExampleSchemaObject:

--- a/test/unit/assertions/differentRequestModules.test.js
+++ b/test/unit/assertions/differentRequestModules.test.js
@@ -133,6 +133,25 @@ describe('Parsing responses from different request modules', function () {
       });
     });
 
+    describe('res has no content-type header, res.body is {}, and res.text is empty string', function() {
+      const res = chai.request(app).get('/test/no/content-type/header/and/no/response/body');
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '204' response defined for endpoint 'GET /test/no/content-type/header/and/no/response/body' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 204,
+              body: {},
+              text: '',
+            })
+          }`
+        );
+      });
+    });
+
   });
 
   describe('supertest', function() {
@@ -210,6 +229,25 @@ describe('Parsing responses from different request modules', function () {
       });
     });
 
+    describe('res has no content-type header, res.body is {}, and res.text is empty string', function() {
+      const res = supertest(app).get('/test/no/content-type/header/and/no/response/body');
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '204' response defined for endpoint 'GET /test/no/content-type/header/and/no/response/body' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 204,
+              body: {},
+              text: '',
+            })
+          }`
+        );
+      });
+    });
+
   });
 
   describe('axios', function() {
@@ -280,6 +318,24 @@ describe('Parsing responses from different request modules', function () {
             util.inspect({
               status: 200,
               body: null,
+            })
+          }`
+        );
+      });
+    });
+
+    describe('res has no content-type header, and res.body is empty string', function() {
+      const res = axios.get(`${appOrigin}/test/no/content-type/header/and/no/response/body`);
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '204' response defined for endpoint 'GET /test/no/content-type/header/and/no/response/body' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 204,
+              body: '',
             })
           }`
         );
@@ -391,6 +447,28 @@ describe('Parsing responses from different request modules', function () {
             util.inspect({
               status: 200,
               body: 'null',
+            })
+          }`
+        );
+      });
+    });
+
+    describe('res has no content-type header, and res.body is empty string', function() {
+      const res = requestPromise({
+        method: 'GET',
+        uri: `${appOrigin}/test/no/content-type/header/and/no/response/body`,
+        resolveWithFullResponse: true,
+      });
+      it('passes', async function() {
+        expect(await res).to.satisfyApiSpec;
+      });
+      it('fails when using .not', function () {
+        const assertion = async() => expect(await res).to.not.satisfyApiSpec;
+        return expect(assertion()).to.be.rejectedWith(
+          `expected res not to satisfy API spec for '204' response defined for endpoint 'GET /test/no/content-type/header/and/no/response/body' in OpenAPI spec\nres: ${
+            util.inspect({
+              status: 204,
+              body: '',
             })
           }`
         );


### PR DESCRIPTION
This PR _fixes https://github.com/RuntimeTools/chai-openapi-response-validator/issues/54 (pending release) by correctly validating responses from Express servers responding via:
* `res.sendStatus(204)`
* `res.status(204).send()`
* `res.status(204).end`
* `res.status(204).json()`

The code checks whether the response has a `content-type` header (and whether the body actually seems to have content).


Notes

1. If your server responds via `res.status(200).json()`, the `content-type` header is `text/plain`. https://expressjs.com/en/api.html#res.json says this is accurate (`res.json` should set a content-type header) but we can change the code if to suit users. 

2. Strictly speaking, https://expressjs.com/en/api.html#res.sendStatus says `res.sendStatus` sends the string representation of the status code as the response body. I would therefore expect the response to have a `content-type` header of `text/plain` or something. However, in these cases the request modules we support return response objects that do not have a `content-type` header. Therefore they seem to treat these 3 equivalently:
    * `res.sendStatus(204)`
    * `res.status(204).send()`
    * `res.status(204).end`