### PR TITLE
Release 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-openapi-response-validator",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-openapi-response-validator",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Simple Chai support for asserting that HTTP responses satisfy an OpenAPI spec",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Features:
* Some TypeScript support! Added a TypeScript Declaration File so you can use this plugin in TypeScript projects without running in type errors https://github.com/RuntimeTools/chai-openapi-response-validator/issues/61. See [usage guide](https://github.com/RuntimeTools/chai-openapi-response-validator#using-this-plugin-in-a-typescript-project)

* Changed some negated assertions to pass instead of fail https://github.com/RuntimeTools/chai-openapi-response-validator/pull/67
`expect(res).to.not.satisfyApiSpec` used to mean "expect `res` to *match but not satisfy* a response defined in your API spec". 
now `expect(res).to.not.satisfyApiSpec` means "expect `res` to *neither match nor satisfy* a response defined in your API spec". 
So if `res` matches no responses in your API spec, then `expect(res).to.not.satisfyApiSpec` passes.

* Much more useful and consistent assertion failure messages https://github.com/RuntimeTools/chai-openapi-response-validator/pull/67: 
     * `expect(response).to.satisfyApiSpec`:
![image](https://user-images.githubusercontent.com/18170169/79115618-36628900-7d7e-11ea-89e3-5458f3989f6d.png)

     * `expect(object).to.satisfySchemaInApiSpec`:
![image](https://user-images.githubusercontent.com/18170169/79115645-48442c00-7d7e-11ea-9c5e-265023f2b4dc.png)


